### PR TITLE
Use custom user-agent

### DIFF
--- a/src/main/java/me/itzg/helpers/get/GetCommand.java
+++ b/src/main/java/me/itzg/helpers/get/GetCommand.java
@@ -138,6 +138,7 @@ public class GetCommand implements Callable<Integer> {
 
         try (CloseableHttpClient client = HttpClients.custom()
             .addExecInterceptorFirst("latchRequestUris", interceptor)
+            .setUserAgent("mc-image-helper/0")
             .build()) {
 
             final PrintWriter stdout = spec.commandLine().getOut();


### PR DESCRIPTION
Using the default user-agent of Apache HttpClient frequently cause Cloudflare protected domains to reject the request.