### PR TITLE
Adding support for wild cards in Assert File Exists

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
     implementation 'org.apache.maven:maven-artifact:3.8.4'
+    implementation 'org.apache.ant:ant:1.10.12'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'

--- a/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
+++ b/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
@@ -1,18 +1,11 @@
 package me.itzg.helpers.assertcmd;
 
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.PathMatcher;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
 import org.apache.tools.ant.DirectoryScanner;
-
 
 @Command(name = "fileExists")
 class FileExists implements Callable<Integer> {
@@ -24,7 +17,6 @@ class FileExists implements Callable<Integer> {
   public Integer call() throws Exception {
     boolean missing = false;
     DirectoryScanner scanner = new DirectoryScanner();
-    //scanner.setBasedir(".");
     scanner.setCaseSensitive(false);
 
     if (paths != null) {

--- a/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
+++ b/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
@@ -1,6 +1,5 @@
 package me.itzg.helpers.assertcmd;
 
-import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
@@ -20,12 +19,14 @@ class FileExists implements Callable<Integer> {
     scanner.setCaseSensitive(false);
 
     if (paths != null) {
-      scanner.setIncludes(paths);
-      scanner.scan();
-      String[] files = scanner.getIncludedFiles();
-      if (files.length < paths.length) {
-        System.err.printf("%s does not exist%n", Arrays.toString(paths));
-        missing = true;
+      for (String path : paths) {
+        scanner.setIncludes(new String[] { path });
+        scanner.scan();
+        String[] files = scanner.getIncludedFiles();
+        if (files.length < 1) {
+          System.err.printf("%s does not exist%n", path);
+          missing = true;
+        }
       }
     }
 

--- a/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
+++ b/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
@@ -1,29 +1,39 @@
 package me.itzg.helpers.assertcmd;
 
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.PathMatcher;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
+import org.apache.tools.ant.DirectoryScanner;
+
 
 @Command(name = "fileExists")
 class FileExists implements Callable<Integer> {
 
   @Parameters
-  List<Path> paths;
+  String[] paths;
 
   @Override
   public Integer call() throws Exception {
     boolean missing = false;
+    DirectoryScanner scanner = new DirectoryScanner();
+    //scanner.setBasedir(".");
+    scanner.setCaseSensitive(false);
 
     if (paths != null) {
-      for (Path path : paths) {
-        if (!Files.exists(path)) {
-          System.err.printf("%s does not exist%n", path);
-          missing = true;
-        }
+      scanner.setIncludes(paths);
+      scanner.scan();
+      String[] files = scanner.getIncludedFiles();
+      if (files.length < paths.length) {
+        System.err.printf("%s does not exist%n", Arrays.toString(paths));
+        missing = true;
       }
     }
 

--- a/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
+++ b/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
@@ -49,8 +49,43 @@ class FileExistsTest {
     });
 
     assertThat(errOut).contains(
-        "fileA does not exist",
-        "fileB does not exist"
+        "does not exist"
+    );
+  }
+
+  @Test
+  void passesWhenGlobFindsAllFiles(@TempDir Path tempDir) throws Exception {
+    Files.createFile(tempDir.resolve("file1"));
+    Files.createFile(tempDir.resolve("file2"));
+
+    final String errOut = tapSystemErr(() -> {
+      int exitCode = new CommandLine(new FileExists())
+          .execute(
+              String.format("%s/file*", tempDir)
+          );
+
+      assertThat(exitCode).isEqualTo(0);
+    });
+
+    assertThat(errOut).isBlank();
+  }
+
+  @Test
+  void failsWhenGlobFailsToFindFiles(@TempDir Path tempDir) throws Exception {
+    Files.createFile(tempDir.resolve("file1"));
+    Files.createFile(tempDir.resolve("file2"));
+
+    final String errOut = tapSystemErr(() -> {
+      int exitCode = new CommandLine(new FileExists())
+          .execute(
+              String.format("%s/fileA*", tempDir)
+          );
+
+      assertThat(exitCode).isEqualTo(1);
+    });
+
+    assertThat(errOut).contains(
+      "does not exist"
     );
   }
 }

--- a/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
+++ b/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
@@ -49,7 +49,8 @@ class FileExistsTest {
     });
 
     assertThat(errOut).contains(
-        "does not exist"
+        "fileA does not exist",
+        "fileB does not exist"
     );
   }
 
@@ -85,7 +86,7 @@ class FileExistsTest {
     });
 
     assertThat(errOut).contains(
-      "does not exist"
+        "fileA* does not exist"
     );
   }
 }


### PR DESCRIPTION
Story:
- Need to Assert file exists using wild cards for MC jar files that continuously change.

Acceptance Criteria: 
- Allow the use of globing to verify if files exist: */*.html etc.

Notes:
- Using [ANT](https://ant.apache.org/manual/api/org/apache/tools/ant/DirectoryScanner.html) to use globbing.
- Added Unit tests for new Globing support