### PR TITLE
fix(assert): adjusted fileExists to support relative paths

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,17 +131,17 @@ dependencies {
     implementation "info.picocli:picocli:${picocliVersion}"
     implementation 'com.fasterxml.jackson.core:jackson-databind'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
-    implementation 'com.jayway.jsonpath:json-path:2.6.0'
+    implementation 'com.jayway.jsonpath:json-path:2.7.0'
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.1.1'
     implementation 'com.squareup.okhttp3:okhttp'
-    implementation 'com.jayway.jsonpath:json-path:2.6.0'
+    implementation 'com.jayway.jsonpath:json-path:2.7.0'
     implementation 'org.apache.maven:maven-artifact:3.8.4'
     implementation 'org.apache.ant:ant:1.10.12'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
-    testImplementation 'org.mockito:mockito-junit-jupiter:4.2.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.3.1'
     testImplementation 'org.mock-server:mockserver-junit-jupiter:5.11.2'
     // https://github.com/stefanbirkner/system-lambda
     testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp'
     implementation 'com.jayway.jsonpath:json-path:2.7.0'
     implementation 'org.apache.maven:maven-artifact:3.8.4'
-    implementation 'org.apache.ant:ant:1.10.12'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'

--- a/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
+++ b/src/main/java/me/itzg/helpers/assertcmd/FileExists.java
@@ -1,29 +1,36 @@
 package me.itzg.helpers.assertcmd;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Parameters;
-import org.apache.tools.ant.DirectoryScanner;
 
 @Command(name = "fileExists")
 class FileExists implements Callable<Integer> {
+  private static final Pattern globSymbols = Pattern.compile("[*?]|\\{.+?}");
+  // matches everything up to the last path separator either / or \
+  private static final Pattern pathSeparators = Pattern.compile(".*[/\\\\]");
 
   @Parameters
-  String[] paths;
+  List<String> paths;
 
   @Override
   public Integer call() throws Exception {
     boolean missing = false;
-    DirectoryScanner scanner = new DirectoryScanner();
-    scanner.setCaseSensitive(false);
 
     if (paths != null) {
       for (String path : paths) {
-        scanner.setIncludes(new String[] { path });
-        scanner.scan();
-        String[] files = scanner.getIncludedFiles();
-        if (files.length < 1) {
+        if (!exists(path)) {
           System.err.printf("%s does not exist%n", path);
           missing = true;
         }
@@ -32,4 +39,38 @@ class FileExists implements Callable<Integer> {
 
     return missing ? ExitCode.SOFTWARE : ExitCode.OK;
   }
+
+  private boolean exists(String pathSpec) throws IOException {
+    final Matcher globMatcher = globSymbols.matcher(pathSpec);
+    // find the first globbing symbol
+    if (!globMatcher.find()) {
+      // no globbing, just a specific path
+      return Files.exists(Paths.get(pathSpec));
+    }
+
+    // find last path separator in the text before the glob
+    final Matcher sepMatcher = pathSeparators.matcher(pathSpec.substring(0, globMatcher.start()));
+    final Path walkStart;
+    // ...by looking from the start of the string
+    if (sepMatcher.lookingAt()) {
+      // ...and grabbing the end of the matched text
+      walkStart = Paths.get(pathSpec.substring(0, sepMatcher.end()));
+    }
+    else {
+      // no separator, so process relative paths
+      walkStart = Paths.get("");
+    }
+
+    final PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher(
+        "glob:" +
+            // escape any Windows backslashes
+            pathSpec.replace("\\", "\\\\")
+    );
+    try (Stream<Path> pathStream = Files.walk(walkStart)) {
+      return pathStream
+          .filter(Files::isRegularFile)
+          .anyMatch(pathMatcher::matches);
+    }
+  }
+
 }

--- a/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
+++ b/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
@@ -102,6 +102,21 @@ class FileExistsTest {
   }
 
   @Test
+  void passesWhenGlobDoubleStarAndMultipleMatches() throws Exception {
+    final String errOut = tapSystemErr(() -> {
+      int exitCode = new CommandLine(new FileExists())
+          .execute(
+              // working directory is top of project
+              "**/gradle-wrapper.*"
+          );
+
+      assertThat(exitCode).isEqualTo(0);
+    });
+
+    assertThat(errOut).isBlank();
+  }
+
+  @Test
   void failsWhenGlobFailsToFindFiles(@TempDir Path tempDir) throws Exception {
     Files.createFile(tempDir.resolve("file1"));
     Files.createFile(tempDir.resolve("file2"));

--- a/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
+++ b/src/test/java/me/itzg/helpers/assertcmd/FileExistsTest.java
@@ -72,6 +72,36 @@ class FileExistsTest {
   }
 
   @Test
+  void passesWhenGlobFileInWorkingDirectory() throws Exception {
+    final String errOut = tapSystemErr(() -> {
+      int exitCode = new CommandLine(new FileExists())
+          .execute(
+              // working directory is top of project
+              "*.md"
+          );
+
+      assertThat(exitCode).isEqualTo(0);
+    });
+
+    assertThat(errOut).isBlank();
+  }
+
+  @Test
+  void passesWhenGlobFileSubdir() throws Exception {
+    final String errOut = tapSystemErr(() -> {
+      int exitCode = new CommandLine(new FileExists())
+          .execute(
+              // working directory is top of project
+              "gradle/wrapper/*.jar"
+          );
+
+      assertThat(exitCode).isEqualTo(0);
+    });
+
+    assertThat(errOut).isBlank();
+  }
+
+  @Test
   void failsWhenGlobFailsToFindFiles(@TempDir Path tempDir) throws Exception {
     Files.createFile(tempDir.resolve("file1"));
     Files.createFile(tempDir.resolve("file2"));


### PR DESCRIPTION
When re-running exists tests in itzg/docker-minecraft-server found that relative paths were never getting matched. Stepping through the ant DirectoryScanner code it appears to be quite complicated and archaic.

This change swaps that out with native PathMatcher usage.