### PR TITLE
fix(modrinth): missing declaration of embedded dependency type

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/model/DependencyType.java
+++ b/src/main/java/me/itzg/helpers/modrinth/model/DependencyType.java
@@ -3,5 +3,6 @@ package me.itzg.helpers.modrinth.model;
 public enum DependencyType {
   required,
   optional,
-  incompatible
+  incompatible,
+  embedded
 }


### PR DESCRIPTION
For https://github.com/itzg/docker-minecraft-server/issues/1697