### PR TITLE
Accept DEBUG env var for enabling debugs

### DIFF
--- a/src/main/java/me/itzg/helpers/McImageHelper.java
+++ b/src/main/java/me/itzg/helpers/McImageHelper.java
@@ -70,8 +70,9 @@ public class McImageHelper {
   boolean showVersion;
 
   @SuppressWarnings("unused")
-  @Option(names = "--debug", description = "Enable debug output. Can also set environment variable DEBUG_HELPER",
-      defaultValue = "${env:DEBUG_HELPER}")
+  @Option(names = "--debug", description = "Enable debug output."
+      + " Can also set environment variables DEBUG_HELPER or DEBUG",
+      defaultValue = "${env:DEBUG_HELPER:-${env:DEBUG}}")
   void setDebug(boolean value) {
     ((Logger) LoggerFactory.getLogger("me.itzg.helpers")).setLevel(
         value ? Level.DEBUG : Level.INFO);

--- a/src/main/java/me/itzg/helpers/errors/ExceptionHandler.java
+++ b/src/main/java/me/itzg/helpers/errors/ExceptionHandler.java
@@ -21,21 +21,8 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
       ParseResult parseResult) {
 
     if (!mcImageHelper.isSilent()) {
-      if (e.getCause() != null) {
-        log.error("'{}' command failed: {} caused by {}",
-            commandLine.getCommandName(),
-            e.getMessage() != null ? e.getMessage() : e.getClass(),
-            e.getCause().getMessage()
-            );
-      }
-      else {
-        log.error("'{}' command failed: {}",
-            commandLine.getCommandName(),
-            e.getMessage() != null ? e.getMessage() : e.getClass());
-      }
+      log.error("'{}' command failed", commandLine.getCommandName(), e);
     }
-
-    log.debug("Details", e);
 
     final IExitCodeExceptionMapper mapper = commandLine.getExitCodeExceptionMapper();
     return mapper != null ? mapper.getExitCode(e) : 1;

--- a/src/main/java/me/itzg/helpers/forge/ForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeInstaller.java
@@ -143,7 +143,7 @@ public class ForgeInstaller {
                 log.debug("Skipping deletion of non-existent file {}", file);
             }
             catch (IOException e) {
-                log.warn("Failed to delete old file {} in {}: {}", file, dir, e.getMessage());
+                log.warn("Failed to delete old file {} in {}", file, dir, e);
             }
         }
     }


### PR DESCRIPTION
Also
- sync: throw exception from sync
- log stack trace with execution exception
- forge: log stack trace when file deletion fails

As noted [in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1054724491244220466), one would think `DEBUG` from the usual startup debugging would work. In #38 I switched the var from DEBUG to DEBUG_HELPER since the output was interfering with script operations using output of helper. In #42 I changed debug logs to go to stderr and should have added back `DEBUG `support.