### PR TITLE
curseforge: allow for any content type for exclude-include download

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
@@ -156,6 +156,7 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
             else {
                 return fetch(excludeIncludeArgs.exludeIncludeFile.getUri())
                     .toObject(ExcludeIncludesContent.class)
+                    .acceptContentTypes(null)
                     .execute();
             }
         }


### PR DESCRIPTION
Observed with
```
--exclude-include-file=https://raw.githubusercontent.com/itzg/docker-minecraft-server/master/files/cf-exclude-include.json
```