### PR TITLE
Allow per project version type declaration

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
@@ -252,9 +252,10 @@ public class ModrinthCommand implements Callable<Integer> {
         final Project project = getProject(projectRefParts[0]);
         if (projectsProcessed.add(project.getId())) {
             final Version version;
-            final String versionIdOrType = projectRefParts[1];
 
             if (projectRefParts.length == 2) {
+                final String versionIdOrType = projectRefParts[1];
+
                 if (EnumUtils.isValidEnum(VersionType.class, versionIdOrType)) {
                     version = pickVersion(getVersionsForProject(project.getId()), VersionType.valueOf(versionIdOrType));
                 } else {


### PR DESCRIPTION
Allow the project version type to be declared using the same method as the version id.
To be honest, this code looks like spaghetti so I will mark this a draft PR.