### PR TITLE
http: pre-encode URIs to fully handle unicode in path

### DIFF
--- a/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
+++ b/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
@@ -36,7 +36,9 @@ public class FetchBuilderBase<SELF extends FetchBuilderBase<SELF>> {
         private final Map<String, String> requestHeaders = new HashMap<>();
 
         State(URI uri, SharedFetch sharedFetch) {
-            this.uri = uri;
+            // Netty seems to half-way URL encode paths that have unicode,
+            // so instead we'll pre-"encode" the URI
+            this.uri = URI.create(uri.toASCIIString());
             this.sharedFetch = sharedFetch;
         }
     }


### PR DESCRIPTION
Resolves #133 