### PR TITLE
modrinth: adapt version lookup API

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
@@ -221,7 +221,7 @@ public class ModrinthCommand implements Callable<Integer> {
         try {
             return fetch(Uris.populateToUri(
                 baseUrl + "/project/{id|slug}/version?loaders={loader}&game_versions={gameVersion}",
-                project, arrayOfQuoted(loader.toString()), arrayOfQuoted(gameVersion)
+                project, loader.toString(), gameVersion
             ))
                 .userAgentCommand("modrinth")
                 .toObjectList(Version.class)
@@ -239,10 +239,6 @@ public class ModrinthCommand implements Callable<Integer> {
                 .userAgentCommand("modrinth")
                 .toObject(Version.class)
                 .execute();
-    }
-
-    private String arrayOfQuoted(String value) {
-        return "[\"" + value + "\"]";
     }
 
     private Stream<? extends Path> processProject(String projectRef) {


### PR DESCRIPTION
It appears that [the API docs](https://docs.modrinth.com/api-spec/#tag/versions/operation/getProjectVersions) are now incorrect in stating the query parameters should be quoted arrays. Instead the API now seems to only return items when using regular values.

For https://github.com/itzg/docker-minecraft-server/issues/1973