### PR TITLE
cf: report missing manifest as invalid parameter

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/model/CurseForgeResponse.java
+++ b/src/main/java/me/itzg/helpers/curseforge/model/CurseForgeResponse.java
@@ -1,0 +1,10 @@
+package me.itzg.helpers.curseforge.model;
+
+import lombok.Data;
+
+@Data
+public class CurseForgeResponse<T> {
+    private boolean ok;
+    private String error;
+    private T data;
+}

--- a/src/main/java/me/itzg/helpers/http/FailedRequestException.java
+++ b/src/main/java/me/itzg/helpers/http/FailedRequestException.java
@@ -3,23 +3,25 @@ package me.itzg.helpers.http;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.net.URI;
 import lombok.Getter;
+import lombok.ToString;
 
+@Getter @ToString
 public class FailedRequestException extends RuntimeException {
 
-    @Getter
     private final URI uri;
-    @Getter
     private final int statusCode;
+    private final String body;
 
     /**
      * Reactor Netty flavor
      */
-    public FailedRequestException(HttpResponseStatus status, URI uri, String msg) {
+    public FailedRequestException(HttpResponseStatus status, URI uri, String body, String msg) {
         super(
             String.format("HTTP request of %s failed with %s: %s", uri, status, msg)
         );
         this.uri = uri;
         this.statusCode = status.code();
+        this.body = body;
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
+++ b/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
@@ -147,6 +147,7 @@ public class FetchBuilderBase<SELF extends FetchBuilderBase<SELF>> {
 
     protected  <R> Mono<R> failedRequestMono(HttpClientResponse resp, ByteBufMono bodyMono, String description) {
         return (bodyMono != null ? bodyMono.asString() : Mono.just(""))
+            .defaultIfEmpty("")
             .flatMap(body -> Mono.error(new FailedRequestException(resp.status(), uri(), body, description)));
     }
 

--- a/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
+++ b/src/main/java/me/itzg/helpers/http/FetchBuilderBase.java
@@ -21,6 +21,7 @@ import me.itzg.helpers.http.SharedFetch.Options;
 import me.itzg.helpers.json.ObjectMappers;
 import org.slf4j.Logger;
 import reactor.core.publisher.Mono;
+import reactor.netty.ByteBufMono;
 import reactor.netty.Connection;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientRequest;
@@ -144,8 +145,9 @@ public class FetchBuilderBase<SELF extends FetchBuilderBase<SELF>> {
             );
     }
 
-    protected  <R> Mono<R> failedRequestMono(HttpClientResponse resp, String description) {
-        return Mono.error(new FailedRequestException(resp.status(), uri(), description));
+    protected  <R> Mono<R> failedRequestMono(HttpClientResponse resp, ByteBufMono bodyMono, String description) {
+        return (bodyMono != null ? bodyMono.asString() : Mono.just(""))
+            .flatMap(body -> Mono.error(new FailedRequestException(resp.status(), uri(), body, description)));
     }
 
     protected static boolean notSuccess(HttpClientResponse resp) {

--- a/src/main/java/me/itzg/helpers/http/ObjectFetchBuilder.java
+++ b/src/main/java/me/itzg/helpers/http/ObjectFetchBuilder.java
@@ -56,7 +56,7 @@ public class ObjectFetchBuilder<T> extends FetchBuilderBase<ObjectFetchBuilder<T
 
     private <R> Mono<R> handleResponse(HttpClientResponse resp, ByteBufMono bodyMono) {
         if (notSuccess(resp)) {
-            return failedRequestMono(resp, "Fetching object content");
+            return failedRequestMono(resp, bodyMono, "Fetching object content");
         }
         if (notExpectedContentType(resp)) {
             return failedContentTypeMono(resp);

--- a/src/main/java/me/itzg/helpers/http/SpecificFileFetchBuilder.java
+++ b/src/main/java/me/itzg/helpers/http/SpecificFileFetchBuilder.java
@@ -106,7 +106,7 @@ public class SpecificFileFetchBuilder extends FetchBuilderBase<SpecificFileFetch
                     }
 
                     if (notSuccess(resp)) {
-                        return failedRequestMono(resp, "Trying to retrieve file");
+                        return failedRequestMono(resp, bodyMono, "Trying to retrieve file");
                     }
 
                     if (notExpectedContentType(resp)) {


### PR DESCRIPTION
Also properly handles and reports a file that isn't present for the requested modpack project.