### PR TITLE
modrinth: option to ignore missing files from modpack update check

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommand.java
@@ -129,7 +129,8 @@ public class InstallModrinthModpackCommand implements Callable<Integer> {
                 outputDirectory,
                 gameVersion,
                 defaultVersionType, loader != null ? loader.asLoader() : null
-            );
+            )
+                .setIgnoreMissingFiles(ignoreMissingFiles);
         }
     }
 }


### PR DESCRIPTION
Was missing propagation of command field to the API fetcher.