### PR TITLE
modrinth: sanitize modpack file's path

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
@@ -112,8 +112,9 @@ public class ModrinthPackInstaller {
             )
             .publishOn(Schedulers.boundedElastic())
             .flatMap(modpackFile -> {
+                final String modpackFilePath = sanitizeModFilePath(modpackFile.getPath());
                 final Path outFilePath =
-                    this.outputDirectory.resolve(modpackFile.getPath());
+                    this.outputDirectory.resolve(modpackFilePath);
                 try {
                     //noinspection BlockingMethodInNonBlockingContext
                     Files.createDirectories(outFilePath.getParent());
@@ -126,9 +127,20 @@ public class ModrinthPackInstaller {
                     outFilePath,
                     modpackFile.getDownloads().get(0),
                     (uri, file, contentSizeBytes) ->
-                        log.info("Downloaded {}", modpackFile.getPath())
+                        log.info("Downloaded {}", modpackFilePath)
                 );
             });
+    }
+
+    private String sanitizeModFilePath(String path) {
+        // Using only backslash delimiters and not forward slashes?
+        // (mixed usage will assume backslashes were purposeful)
+        if (path.contains("\\") && !path.contains("/")) {
+            return path.replace("\\", "/");
+        }
+        else {
+            return path;
+        }
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommandTest.java
@@ -47,7 +47,7 @@ public class InstallModrinthModpackCommandTest {
         String expectedFileData = "some test data";
         String relativeFilePath = "test_file";
         ModpackFile testFile = createHostedModpackFile(
-            relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
+            relativeFilePath, relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
 
         ModpackIndex index = createBasicModpackIndex();
         index.getFiles().add(testFile);
@@ -74,7 +74,7 @@ public class InstallModrinthModpackCommandTest {
         String expectedFileData = "some test data";
         String relativeFilePath = "test_file";
         ModpackFile testFile = createHostedModpackFile(
-            relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
+            relativeFilePath, relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
 
         ModpackIndex index = createBasicModpackIndex();
         index.getFiles().add(testFile);
@@ -161,7 +161,7 @@ public class InstallModrinthModpackCommandTest {
         String expectedFileData = "some test data";
         String relativeFilePath = "test_file";
         ModpackFile testFile = createHostedModpackFile(
-            relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
+            relativeFilePath, relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
 
         ModpackIndex index = createBasicModpackIndex();
         index.getFiles().add(testFile);
@@ -201,7 +201,7 @@ public class InstallModrinthModpackCommandTest {
         String relativeFilePath = "test_file";
         String modpackDownloadPath = "/files/modpacks/test_modpack-1.0.0.mrpack";
         ModpackFile testFile = createHostedModpackFile(
-            relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
+            relativeFilePath, relativeFilePath, expectedFileData, wm.getHttpBaseUrl());
 
         ModpackIndex index = createBasicModpackIndex();
         index.getFiles().add(testFile);

--- a/src/test/java/me/itzg/helpers/modrinth/ModrinthTestHelpers.java
+++ b/src/test/java/me/itzg/helpers/modrinth/ModrinthTestHelpers.java
@@ -101,17 +101,17 @@ class ModrinthTestHelpers {
     }
 
     static ModpackIndex.ModpackFile createHostedModpackFile(
-            String relativeFileLocation, String data, String wmBaseUrl
+            String relativeFileLocation, String urlSubpath, String data, String wmBaseUrl
         ) throws URISyntaxException
     {
-        stubFor(get("/files/" + relativeFileLocation)
+        stubFor(get("/files/" + urlSubpath)
             .willReturn(ok().withBody(data)));
 
         ModpackIndex.ModpackFile modpackFile = new ModpackIndex.ModpackFile()
             .setDownloads(new ArrayList<>())
             .setPath(relativeFileLocation);
         modpackFile.getDownloads().add(
-            new URI(wmBaseUrl + "/files/" + relativeFileLocation));
+            new URI(wmBaseUrl + "/files/" + urlSubpath));
 
         return modpackFile;
     }


### PR DESCRIPTION
[This modpack's index](https://cdn-raw.modrinth.com/data/vwgtbO0y/versions/pcBAoLzK/The%20Pixelmon%20Modpack%209.2.3.mrpack) used backslashes in the file paths:

```json
{
  "formatVersion": 1,
  "game": "minecraft",
  "versionId": "Pixelmon-1.20.1-9.2.3",
  "name": "Pixelmon Mod",
  "summary": "You probably all know Pokemon. Pixelmon is basically the same only it is on a Minecraft server! You can catch pokemon, battle trainers, compete with each other and against other pokemon, earn gym badges, upgrade your pokemons with attacks and trade with each other. \r\n\r\nThis pack requires 800mb to 2gb of RAM for optimal performance. \r\nJava 17 - 64 bit is required. \r\n\r\nWebsite:\r\nhttps://pixelmonmod.com/\r\nhttps://www.reforged.gg/",
  "files": [
    {
      "path": "mods\\Pixelmon-1.20.1-9.2.3-universal.jar",
      "hashes": {
        "sha512": "3a9c6f375214c6d93c6cce8235e8a206e8f9731be8e168a254e78539087080796d97f0b22cb9a6db09d901c72e2e1ae53b9f2484761fb310479ce9f84ac9b145",
        "sha1": "d1505ce56f683053e5f4b69b2c61374d1ea54f9d"
      },
```

