### PR TITLE
http: allow configurable connection pool acquire timeout

### DIFF
--- a/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
@@ -1,9 +1,8 @@
 package me.itzg.helpers.http;
 
+import java.time.Duration;
 import me.itzg.helpers.http.SharedFetch.Options;
 import picocli.CommandLine.Option;
-
-import java.time.Duration;
 
 /**
  * Usage:
@@ -40,6 +39,13 @@ public class SharedFetchArgs {
     )
     public void setConnectionPoolMaxIdleTimeout(Duration timeout) {
         optionsBuilder.maxIdleTimeout(timeout);
+    }
+
+    @Option(names = "--connection-pool-pending-acquire-timeout", defaultValue = "${env:FETCH_CONNECTION_POOL_PENDING_ACQUIRE_TIMEOUT}",
+        paramLabel = "DURATION"
+    )
+    public void setPendingAcquireTimeout(Duration timeout) {
+        optionsBuilder.pendingAcquireTimeout(timeout);
     }
 
     public Options options() {


### PR DESCRIPTION
Mentioned a few times in Discord, [such as this one](https://discord.com/channels/660567679458869252/660569755320844308/1175095138247262249).

Also increased from Netty's default of 45 seconds to 2 minutes.