### PR TITLE
Use proxyWithSystemProperties in SharedFetch

### DIFF
--- a/src/main/java/me/itzg/helpers/http/SharedFetch.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetch.java
@@ -55,6 +55,7 @@ public class SharedFetch implements AutoCloseable {
             .build();
 
         reactiveClient = HttpClient.create(connectionProvider)
+            .proxyWithSystemProperties()
             .headers(headers -> {
                     headers
                         .set(HttpHeaderNames.USER_AGENT.toString(), userAgent)


### PR DESCRIPTION
Similar to https://github.com/itzg/mc-image-helper/pull/20

This change allows the container to use my proxy server when downloading fabric server if I add (not sure which of these is used by the tool, but IIRC both are needed):
```yaml
environment:
  # use proxy server: 10.0.16.7:3128
  HTTP_PROXY: "http://10.0.16.7:3128"
  JAVA_TOOL_OPTIONS: "-Dhttps.proxyHost=10.0.16.7 -Dhttps.proxyPort=3128 -XX:+PerfDisableSharedMem"
```