### PR TITLE
Fix exception in FilenameExtractor.filenameFromContentDisposition

### DIFF
--- a/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
+++ b/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
@@ -45,7 +45,7 @@ public class FilenameExtractor {
                 try {
                     return Rfc5987Util.decode(m.group(2), m.group(1));
                 } catch (UnsupportedEncodingException e) {
-                    log.debug("Failed to decode filename* from {}", headerValue);
+                    log.warn("Failed to decode filename* from {}", headerValue);
                     return null;
                 }
             }

--- a/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
+++ b/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
@@ -6,7 +6,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
-import me.itzg.helpers.errors.GenericException;
 import org.apache.cxf.attachment.Rfc5987Util;
 import org.apache.hc.client5.http.HttpResponseException;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -15,6 +14,7 @@ import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ProtocolException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public class FilenameExtractor {
@@ -30,7 +30,7 @@ public class FilenameExtractor {
         this.interceptor = Objects.requireNonNull(interceptor, "interceptor is required");
     }
 
-    static String filenameFromContentDisposition(String headerValue) {
+    static @Nullable String filenameFromContentDisposition(String headerValue) {
         if (headerValue == null) {
             return null;
         }
@@ -45,7 +45,8 @@ public class FilenameExtractor {
                 try {
                     return Rfc5987Util.decode(m.group(2), m.group(1));
                 } catch (UnsupportedEncodingException e) {
-                    throw new GenericException("Failed to decode filename* from " + headerValue, e);
+                    log.debug("Failed to decode filename* from {}", headerValue);
+                    return null;
                 }
             }
             else {
@@ -62,7 +63,8 @@ public class FilenameExtractor {
             }
         }
         else {
-            throw new GenericException("Unable to determine filename from header: " + headerValue);
+            log.debug("Unable to determine filename from header: {}", headerValue);
+            return null;
         }
     }
 

--- a/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
+++ b/src/main/java/me/itzg/helpers/http/FilenameExtractor.java
@@ -24,69 +24,69 @@ public class FilenameExtractor {
     private static final Pattern RFC_2047_ENCODED = Pattern.compile("=\\?UTF-8\\?Q\\?(.+)\\?=");
     private static final Pattern RFC_5987_ENCODED = Pattern.compile("(UTF-8|ISO-8859-1)''(.+)");
 
-  private final LatchingUrisInterceptor interceptor;
+    private final LatchingUrisInterceptor interceptor;
 
-  public FilenameExtractor(LatchingUrisInterceptor interceptor) {
-    this.interceptor = Objects.requireNonNull(interceptor, "interceptor is required");
-  }
-
-  static String filenameFromContentDisposition(String headerValue) {
-      if (headerValue == null) {
-          return null;
-      }
-
-      final ContentType parsed = ContentType.parse(headerValue);
-      log.debug("Response has contentDisposition={}", headerValue);
-      final String filenameStar = parsed.getParameter("filename*");
-      final String filename = parsed.getParameter("filename");
-      if (filenameStar != null) {
-          final Matcher m = RFC_5987_ENCODED.matcher(filenameStar);
-          if (m.matches()) {
-              try {
-                  return Rfc5987Util.decode(m.group(2), m.group(1));
-              } catch (UnsupportedEncodingException e) {
-                  throw new GenericException("Failed to decode filename* from " + headerValue, e);
-              }
-          }
-          else {
-              return filenameStar;
-          }
-      }
-      else if (filename != null) {
-          final Matcher m = RFC_2047_ENCODED.matcher(filename);
-          if (m.matches()) {
-              return m.group(1);
-          }
-          else {
-              return filename;
-          }
-      }
-      else {
-          throw new GenericException("Unable to determine filename from header: " + headerValue);
-      }
-  }
-
-  public String extract(ClassicHttpResponse response) throws IOException, ProtocolException {
-    // Same as AbstractHttpClientResponseHandler
-    if (response.getCode() >= HttpStatus.SC_REDIRECTION) {
-      EntityUtils.consume(response.getEntity());
-      throw new HttpResponseException(response.getCode(), response.getReasonPhrase());
+    public FilenameExtractor(LatchingUrisInterceptor interceptor) {
+        this.interceptor = Objects.requireNonNull(interceptor, "interceptor is required");
     }
 
-    final Header contentDisposition = response
-        .getHeader("content-disposition");
+    static String filenameFromContentDisposition(String headerValue) {
+        if (headerValue == null) {
+            return null;
+        }
 
-    String filename = null;
-    if (contentDisposition != null) {
-      filename = filenameFromContentDisposition(contentDisposition.getValue());
-    }
-    if (filename == null) {
-      final String path = interceptor.getLastRequestedUri().getPath();
-      log.debug("Deriving filename from response path={}", path);
-      final int pos = path.lastIndexOf('/');
-      filename = path.substring(pos >= 0 ? pos + 1 : 0);
+        final ContentType parsed = ContentType.parse(headerValue);
+        log.debug("Response has contentDisposition={}", headerValue);
+        final String filenameStar = parsed.getParameter("filename*");
+        final String filename = parsed.getParameter("filename");
+        if (filenameStar != null) {
+            final Matcher m = RFC_5987_ENCODED.matcher(filenameStar);
+            if (m.matches()) {
+                try {
+                    return Rfc5987Util.decode(m.group(2), m.group(1));
+                } catch (UnsupportedEncodingException e) {
+                    throw new GenericException("Failed to decode filename* from " + headerValue, e);
+                }
+            }
+            else {
+                return filenameStar;
+            }
+        }
+        else if (filename != null) {
+            final Matcher m = RFC_2047_ENCODED.matcher(filename);
+            if (m.matches()) {
+                return m.group(1);
+            }
+            else {
+                return filename;
+            }
+        }
+        else {
+            throw new GenericException("Unable to determine filename from header: " + headerValue);
+        }
     }
 
-    return filename;
-  }
+    public String extract(ClassicHttpResponse response) throws IOException, ProtocolException {
+        // Same as AbstractHttpClientResponseHandler
+        if (response.getCode() >= HttpStatus.SC_REDIRECTION) {
+            EntityUtils.consume(response.getEntity());
+            throw new HttpResponseException(response.getCode(), response.getReasonPhrase());
+        }
+
+        final Header contentDisposition = response
+            .getHeader("content-disposition");
+
+        String filename = null;
+        if (contentDisposition != null) {
+            filename = filenameFromContentDisposition(contentDisposition.getValue());
+        }
+        if (filename == null) {
+            final String path = interceptor.getLastRequestedUri().getPath();
+            log.debug("Deriving filename from response path={}", path);
+            final int pos = path.lastIndexOf('/');
+            filename = path.substring(pos >= 0 ? pos + 1 : 0);
+        }
+
+        return filename;
+    }
 }


### PR DESCRIPTION
This PR modifies the method `filenameFromContentDisposition` in `FilenameExtractor` to return null instead of throwing an exception if a filename cannot be extracted from the header.

This allows a filename to still be determined by response path if not correctly determined by the header.
