### PR TITLE
users: add support for playerdb lookup and use by default

### DIFF
--- a/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
+++ b/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
@@ -15,19 +15,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidParameterException;
-import me.itzg.helpers.http.FailedRequestException;
 import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
-import me.itzg.helpers.http.UriBuilder;
 import me.itzg.helpers.http.Uris;
 import me.itzg.helpers.json.ObjectMappers;
-import me.itzg.helpers.users.ext.MojangProfile;
 import me.itzg.helpers.users.model.JavaOp;
 import me.itzg.helpers.users.model.JavaUser;
 import org.apache.maven.artifact.versioning.ComparableVersion;
@@ -41,8 +36,6 @@ import picocli.CommandLine.Parameters;
 @Slf4j
 public class ManageUsersCommand implements Callable<Integer> {
 
-    private static final Pattern ID_OR_UUID = Pattern.compile("(?<nonDashed>[a-f0-9]{32})"
-        + "|(?<dashed>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})");
     private static final TypeReference<List<JavaOp>> LIST_OF_JAVA_OP = new TypeReference<List<JavaOp>>() {
     };
     private static final TypeReference<List<JavaUser>> LIST_OF_JAVA_USER = new TypeReference<List<JavaUser>>() {
@@ -69,8 +62,16 @@ public class ManageUsersCommand implements Callable<Integer> {
     @Option(names = {"-f", "--input-is-file"})
     boolean inputIsFile;
 
-    @Option(names = "--mojang-api-base-url", defaultValue = "${env:MOJANG_API_BASE_URL:-https://api.mojang.com/}")
+    @Option(names = "--mojang-api-base-url", defaultValue = "${env:MOJANG_API_BASE_URL:-https://api.mojang.com}")
     String mojangApiBaseUrl;
+
+    @Option(names = "--playerdb-api-base-url", defaultValue = "${env:PLAYERDB_API_BASE_URL:-https://playerdb.co}")
+    String playerdbApiBaseUrl;
+
+    @Option(names = "--user-api-provider", defaultValue = "${env:USER_API_PROVIDER:-playerdb}",
+        description = "Allowed: ${COMPLETION-CANDIDATES}"
+    )
+    UserApiProvider userApiProvider;
 
     @ArgGroup(exclusive = false)
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
@@ -150,8 +151,7 @@ public class ManageUsersCommand implements Callable<Integer> {
         return false;
     }
 
-    private List<? extends JavaUser> reconcile(SharedFetch sharedFetch, List<String> inputs, List<? extends JavaUser> existing)
-        throws IOException {
+    private List<? extends JavaUser> reconcile(SharedFetch sharedFetch, List<String> inputs, List<? extends JavaUser> existing) {
 
         final List<JavaUser> reconciled;
         if (existingFileBehavior == ExistingFileBehavior.MERGE) {
@@ -196,92 +196,64 @@ public class ManageUsersCommand implements Callable<Integer> {
         return false;
     }
 
-    private JavaUser resolveJavaUserId(SharedFetch sharedFetch, List<? extends JavaUser> existing, String input)
-        throws IOException {
-        final Matcher uuidMatcher = ID_OR_UUID.matcher(input);
-        if (uuidMatcher.matches()) {
-            final String dashed = uuidMatcher.group("dashed");
-            final String uuid = dashed != null ? dashed :
-                addDashesToId(uuidMatcher.group("nonDashed"));
+    private JavaUser resolveJavaUserId(SharedFetch sharedFetch, List<? extends JavaUser> existing, String input) {
 
-            for (final JavaUser existingUser : existing) {
-                if (existingUser.getUuid().equalsIgnoreCase(uuid)) {
-                    log.debug("Resolved '{}' from existing user entry by UUID: {}", input, existingUser);
-                    return existingUser;
-                }
-            }
-
-            log.debug("Resolved '{}' into new user entry", input);
-            return JavaUser.builder()
-                .uuid(uuid)
-                // username needs to be present, but content doesn't matter
-                .name("")
-                .build();
-        }
-
-        // ...or username
-        for (final JavaUser existingUser : existing) {
-            if (existingUser.getName().equalsIgnoreCase(input)) {
-                log.debug("Resolved '{}' from existing user entry by name: {}", input, existingUser);
-                return existingUser;
-            }
-        }
-
-        final Path userCacheFile = outputDirectory.resolve("usercache.json");
-        if (Files.exists(userCacheFile)) {
-            final List<JavaUser> userCache = objectMapper.readValue(userCacheFile.toFile(), LIST_OF_JAVA_USER);
-            for (final JavaUser existingUser : userCache) {
-                if (existingUser.getName().equalsIgnoreCase(input)) {
-                    log.debug("Resolved '{}' from user cache by name: {}", input, existingUser);
-                    return existingUser;
-                }
-            }
-        }
-
-        return resolveUserFromApi(sharedFetch, input);
-    }
-
-    private JavaUser resolveUserFromApi(SharedFetch sharedFetch, String input) {
-        log.debug("Resolving user={} from Mojang API at {}", input, mojangApiBaseUrl);
-        final UriBuilder uriBuilder = UriBuilder.withBaseUrl(mojangApiBaseUrl);
-        final MojangProfile profile = sharedFetch.fetch(
-                uriBuilder.resolve("/users/profiles/minecraft/{username}", input)
-            )
-            .toObject(MojangProfile.class)
-            .assemble()
-            .onErrorMap(e -> {
-                if (e instanceof FailedRequestException) {
-                    if (((FailedRequestException) e).getStatusCode() == 404) {
-                        return new InvalidParameterException("Could not resolve username from Mojang: " + input);
+        return UuidQuirks.ifIdOrUuid(input, uuid -> {
+                for (final JavaUser existingUser : existing) {
+                    if (existingUser.getUuid().equalsIgnoreCase(uuid)) {
+                        log.debug("Resolved '{}' from existing user entry by UUID: {}", input, existingUser);
+                        return existingUser;
                     }
                 }
-                return e;
+
+                log.debug("Resolved '{}' into new user entry", input);
+                return JavaUser.builder()
+                    .uuid(uuid)
+                    // username needs to be present, but content doesn't matter
+                    .name("")
+                    .build();
+
             })
-            .block();
+            .orElseGet(() -> {
 
-        if (profile == null) {
-            throw new GenericException("Profile was not available from Mojang for " + input);
-        }
+                // ...or username
+                for (final JavaUser existingUser : existing) {
+                    if (existingUser.getName().equalsIgnoreCase(input)) {
+                        log.debug("Resolved '{}' from existing user entry by name: {}", input, existingUser);
+                        return existingUser;
+                    }
+                }
 
-        log.debug("Resolved '{}' from Mojang profile lookup: {}", input, profile);
-        return JavaUser.builder()
-            .name(profile.getName())
-            .uuid(addDashesToId(profile.getId()))
-            .build();
-    }
+                final Path userCacheFile = outputDirectory.resolve("usercache.json");
+                if (Files.exists(userCacheFile)) {
+                    try {
+                        final List<JavaUser> userCache = objectMapper.readValue(userCacheFile.toFile(), LIST_OF_JAVA_USER);
+                        for (final JavaUser existingUser : userCache) {
+                            if (existingUser.getName().equalsIgnoreCase(input)) {
+                                log.debug("Resolved '{}' from user cache by name: {}", input, existingUser);
+                                return existingUser;
+                            }
+                        }
+                    } catch (IOException e) {
+                        log.error("Failed to parse usercache.json", e);
+                    }
+                }
 
-    private static String addDashesToId(String nonDashed) {
-        if (nonDashed.length() != 32) {
-            throw new IllegalArgumentException("Input needs to be 32 characters: " + nonDashed);
-        }
+                final UserApi userApi;
+                switch (userApiProvider) {
+                    case mojang:
+                        userApi = new MojangUserApi(sharedFetch, mojangApiBaseUrl);
+                        break;
+                    case playerdb:
+                        userApi = new PlayerdbUserApi(sharedFetch, playerdbApiBaseUrl);
+                        break;
+                    default:
+                        throw new GenericException("User API provider was not specified");
+                }
+                return userApi.resolveUser(input);
 
-        return String.join("-",
-            nonDashed.substring(0, 8),
-            nonDashed.substring(8, 12),
-            nonDashed.substring(12, 16),
-            nonDashed.substring(16, 20),
-            nonDashed.substring(20, 32)
-        );
+            });
+
     }
 
     private List<? extends JavaUser> loadExistingJavaJson(Path userFile) throws IOException {
@@ -311,8 +283,7 @@ public class ManageUsersCommand implements Callable<Integer> {
 
     private void verifyNotUuids(List<String> inputs) {
         for (final String input : inputs) {
-            final Matcher m = ID_OR_UUID.matcher(input);
-            if (m.matches()) {
+            if (UuidQuirks.isIdOrUuid(input)) {
                 throw new InvalidParameterException("UUID cannot be provided: " + input);
             }
         }

--- a/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
+++ b/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
@@ -198,7 +198,8 @@ public class ManageUsersCommand implements Callable<Integer> {
 
     private JavaUser resolveJavaUserId(SharedFetch sharedFetch, List<? extends JavaUser> existing, String input) {
 
-        return UuidQuirks.ifIdOrUuid(input, uuid -> {
+        return UuidQuirks.ifIdOrUuid(input)
+            .map(uuid -> {
                 for (final JavaUser existingUser : existing) {
                     if (existingUser.getUuid().equalsIgnoreCase(uuid)) {
                         log.debug("Resolved '{}' from existing user entry by UUID: {}", input, existingUser);

--- a/src/main/java/me/itzg/helpers/users/MojangUserApi.java
+++ b/src/main/java/me/itzg/helpers/users/MojangUserApi.java
@@ -1,0 +1,51 @@
+package me.itzg.helpers.users;
+
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.http.FailedRequestException;
+import me.itzg.helpers.http.SharedFetch;
+import me.itzg.helpers.http.UriBuilder;
+import me.itzg.helpers.users.ext.MojangProfile;
+import me.itzg.helpers.users.model.JavaUser;
+
+@Slf4j
+public class MojangUserApi implements UserApi {
+    private final SharedFetch sharedFetch;
+    private final UriBuilder uriBuilder;
+
+    public MojangUserApi(SharedFetch sharedFetch, String apiBaseUrl) {
+        this.sharedFetch = sharedFetch;
+        this.uriBuilder = UriBuilder.withBaseUrl(apiBaseUrl);
+    }
+
+    @Override
+    public JavaUser resolveUser(String input) {
+        log.debug("Resolving user={} from Mojang API", input);
+        final MojangProfile profile = sharedFetch.fetch(
+                uriBuilder.resolve("/users/profiles/minecraft/{username}", input)
+            )
+            .toObject(MojangProfile.class)
+            .assemble()
+            .onErrorMap(e -> {
+                if (e instanceof FailedRequestException) {
+                    if (((FailedRequestException) e).getStatusCode() == 404) {
+                        return new InvalidParameterException("Could not resolve username from Mojang: " + input);
+                    }
+                }
+                return e;
+            })
+            .block();
+
+        if (profile == null) {
+            throw new GenericException("Profile was not available from Mojang for " + input);
+        }
+
+        log.debug("Resolved '{}' from Mojang profile lookup: {}", input, profile);
+        return JavaUser.builder()
+            .name(profile.getName())
+            .uuid(UuidQuirks.addDashesToId(profile.getId()))
+            .build();
+    }
+
+}

--- a/src/main/java/me/itzg/helpers/users/PlayerdbUserApi.java
+++ b/src/main/java/me/itzg/helpers/users/PlayerdbUserApi.java
@@ -1,0 +1,53 @@
+package me.itzg.helpers.users;
+
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.http.FailedRequestException;
+import me.itzg.helpers.http.SharedFetch;
+import me.itzg.helpers.http.UriBuilder;
+import me.itzg.helpers.users.ext.PlayerdbResponse;
+import me.itzg.helpers.users.model.JavaUser;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class PlayerdbUserApi implements UserApi {
+    private final SharedFetch sharedFetch;
+    private final UriBuilder urlBuilder;
+
+    public PlayerdbUserApi(SharedFetch sharedFetch, String apiBaseUrl) {
+        this.sharedFetch = sharedFetch;
+        this.urlBuilder = UriBuilder.withBaseUrl(apiBaseUrl);
+    }
+
+    @Override
+    public JavaUser resolveUser(String input) {
+        log.debug("Resolving user={} from PlayerDB API", input);
+        return sharedFetch.fetch(
+            urlBuilder.resolve("/api/player/minecraft/{input}", input)
+        )
+            .toObject(PlayerdbResponse.class)
+            .assemble()
+            .onErrorMap(FailedRequestException.class, e -> {
+                if (e.getStatusCode() == 400 || e.getStatusCode() == 404) {
+                    return new InvalidParameterException("Could not resolve user from Playerdb: " + input);
+                }
+                return e;
+            })
+            .flatMap(resp -> {
+                if (resp.isSuccess()) {
+                    return Mono.just(
+                        JavaUser.builder()
+                            .name(resp.getData().getPlayer().getUsername())
+                            .uuid(resp.getData().getPlayer().getId())
+                            .build()
+                    );
+                }
+                else {
+                    return Mono.error(
+                        new InvalidParameterException("Could not resolve user from Playerdb: " + input)
+                    );
+                }
+            })
+            .block();
+    }
+}

--- a/src/main/java/me/itzg/helpers/users/UserApi.java
+++ b/src/main/java/me/itzg/helpers/users/UserApi.java
@@ -1,0 +1,8 @@
+package me.itzg.helpers.users;
+
+import me.itzg.helpers.users.model.JavaUser;
+
+public interface UserApi {
+
+    JavaUser resolveUser(String input);
+}

--- a/src/main/java/me/itzg/helpers/users/UserApiProvider.java
+++ b/src/main/java/me/itzg/helpers/users/UserApiProvider.java
@@ -1,0 +1,6 @@
+package me.itzg.helpers.users;
+
+public enum UserApiProvider {
+    mojang,
+    playerdb
+}

--- a/src/main/java/me/itzg/helpers/users/UuidQuirks.java
+++ b/src/main/java/me/itzg/helpers/users/UuidQuirks.java
@@ -1,0 +1,57 @@
+package me.itzg.helpers.users;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Handles quirky stuff with UUIDs in Mojang's API response, etc
+ */
+public class UuidQuirks {
+
+    static final Pattern ID_OR_UUID = Pattern.compile("(?<nonDashed>[a-f0-9]{32})"
+        + "|(?<dashed>[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})");
+
+    public static String addDashesToId(String nonDashed) {
+        if (nonDashed.length() != 32) {
+            throw new IllegalArgumentException("Input needs to be 32 characters: " + nonDashed);
+        }
+
+        return String.join("-",
+            nonDashed.substring(0, 8),
+            nonDashed.substring(8, 12),
+            nonDashed.substring(12, 16),
+            nonDashed.substring(16, 20),
+            nonDashed.substring(20, 32)
+        );
+    }
+
+    public static boolean isIdOrUuid(String input) {
+        return ID_OR_UUID.matcher(input).matches();
+    }
+
+    @FunctionalInterface
+    public interface UuidHandler<T> {
+
+        T handle(String uuid);
+    }
+
+    public static <T> Optional<T> ifIdOrUuid(String input, UuidHandler<T> handler) {
+        final Matcher uuidMatcher = UuidQuirks.ID_OR_UUID.matcher(input);
+        if (uuidMatcher.matches()) {
+            final String uuid = UuidQuirks.normalizeToUuid(uuidMatcher);
+
+            return Optional.of(handler.handle(uuid));
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+
+    static String normalizeToUuid(Matcher uuidMatcher) {
+        final String dashed = uuidMatcher.group("dashed");
+
+        return dashed != null ? dashed :
+            UuidQuirks.addDashesToId(uuidMatcher.group("nonDashed"));
+    }
+}

--- a/src/main/java/me/itzg/helpers/users/UuidQuirks.java
+++ b/src/main/java/me/itzg/helpers/users/UuidQuirks.java
@@ -30,18 +30,17 @@ public class UuidQuirks {
         return ID_OR_UUID.matcher(input).matches();
     }
 
-    @FunctionalInterface
-    public interface UuidHandler<T> {
-
-        T handle(String uuid);
-    }
-
-    public static <T> Optional<T> ifIdOrUuid(String input, UuidHandler<T> handler) {
+    /**
+     *
+     * @param input ID (no dashes), UUID, or something else, like a username
+     * @return if input is a valid ID/UUID, populated and normalized UUID string
+     */
+    public static Optional<String> ifIdOrUuid(String input) {
         final Matcher uuidMatcher = UuidQuirks.ID_OR_UUID.matcher(input);
         if (uuidMatcher.matches()) {
             final String uuid = UuidQuirks.normalizeToUuid(uuidMatcher);
 
-            return Optional.of(handler.handle(uuid));
+            return Optional.of(uuid);
         }
         else {
             return Optional.empty();

--- a/src/main/java/me/itzg/helpers/users/ext/PlayerdbPlayer.java
+++ b/src/main/java/me/itzg/helpers/users/ext/PlayerdbPlayer.java
@@ -1,0 +1,13 @@
+package me.itzg.helpers.users.ext;
+
+import lombok.Data;
+
+@Data
+public class PlayerdbPlayer {
+    /**
+     * Mojang raw ID, which is a UUID without dashes
+     */
+    private String rawId;
+    private String id;
+    private String username;
+}

--- a/src/main/java/me/itzg/helpers/users/ext/PlayerdbResponse.java
+++ b/src/main/java/me/itzg/helpers/users/ext/PlayerdbResponse.java
@@ -1,0 +1,16 @@
+package me.itzg.helpers.users.ext;
+
+import lombok.Data;
+
+@Data
+public class PlayerdbResponse{
+    private String code;
+    private Data data;
+    private boolean success;
+    private String message;
+
+    @lombok.Data
+    public static class Data {
+        private PlayerdbPlayer player;
+    }
+}

--- a/src/test/java/me/itzg/helpers/users/ManageUsersCommandTest.java
+++ b/src/test/java/me/itzg/helpers/users/ManageUsersCommandTest.java
@@ -42,6 +42,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "user1", "user2"
@@ -86,6 +87,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "user1", "user2"
@@ -131,6 +133,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString()
                 );
@@ -164,6 +167,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "user1"
@@ -205,6 +209,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "user1"
@@ -246,6 +251,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "--existing", "MERGE",
@@ -292,6 +298,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     "--existing", "SKIP",
@@ -324,6 +331,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     USER1_UUID, USER2_ID
@@ -368,6 +376,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_WHITELIST",
                     "--output-directory", tempDir.toString(),
                     // mix of ID and UUIDs
@@ -471,8 +480,9 @@ class ManageUsersCommandTest {
 
     @Nested
     public class ops {
-        @Test
-        void givenNames(WireMockRuntimeInfo wmInfo) {
+        @ParameterizedTest
+        @EnumSource(UserApiProvider.class)
+        void givenNames(UserApiProvider apiProvider, WireMockRuntimeInfo wmInfo) {
             setupUserStubs();
 
             final int exitCode = new CommandLine(
@@ -480,6 +490,8 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--playerdb-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", apiProvider.name(),
                     "--type", "JAVA_OPS",
                     "--output-directory", tempDir.toString(),
                     "user1", "user2"
@@ -507,8 +519,9 @@ class ManageUsersCommandTest {
                 );
         }
 
-        @Test
-        void givenNamesWithExtraSpace(WireMockRuntimeInfo wmInfo) {
+        @ParameterizedTest
+        @EnumSource(UserApiProvider.class)
+        void givenNamesWithExtraSpace(UserApiProvider apiProvider, WireMockRuntimeInfo wmInfo) {
             setupUserStubs();
 
             final int exitCode = new CommandLine(
@@ -516,6 +529,8 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--playerdb-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", apiProvider.name(),
                     "--type", "JAVA_OPS",
                     "--output-directory", tempDir.toString(),
                     " user1"
@@ -558,6 +573,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", "JAVA_OPS",
                     "--output-directory", tempDir.toString(),
                     "user1", "user2"
@@ -607,6 +623,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", type.name(),
                     "--output-directory", tempDir.toString(),
                     "--input-is-file",
@@ -642,6 +659,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", type.name(),
                     "--output-directory", tempDir.toString(),
                     "--input-is-file",
@@ -674,6 +692,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", type.name(),
                     "--output-directory", tempDir.toString(),
                     "--input-is-file",
@@ -703,6 +722,7 @@ class ManageUsersCommandTest {
             )
                 .execute(
                     "--mojang-api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--user-api-provider", "mojang",
                     "--type", type.name(),
                     "--output-directory", tempDir.toString(),
                     "--input-is-file",
@@ -720,23 +740,59 @@ class ManageUsersCommandTest {
     }
 
     private static void setupUserStubs() {
-        stubFor(get("/users/profiles/minecraft/user1")
+        stubMojangUser("user1", USER1_ID);
+        stubMojangUser("user2", USER2_ID);
+
+        stubPlayerdbUser("user1", USER1_UUID, USER1_ID);
+        stubPlayerdbUser("user2", USER2_UUID, USER2_ID);
+    }
+
+    private static void stubMojangUser(String username, String id) {
+        stubFor(get("/users/profiles/minecraft/"
+            + username)
             .willReturn(
                 aResponse()
                     .withHeader("Content-Type", "application/json")
                     .withBody("{\n"
-                        + "  \"id\": \"" + USER1_ID + "\",\n"
-                        + "  \"name\": \"user1\"\n"
+                        + "  \"id\": \"" + id + "\",\n"
+                        + "  \"name\": \""
+                        + username
+                        + "\"\n"
                         + "}")
             )
         );
-        stubFor(get("/users/profiles/minecraft/user2")
+    }
+
+    private static void stubPlayerdbUser(String username, String uuid, String id) {
+        stubFor(get("/api/player/minecraft/"
+            + username)
             .willReturn(
                 aResponse()
+                    .withTransformers("response-template")
                     .withHeader("Content-Type", "application/json")
                     .withBody("{\n"
-                        + "  \"id\": \"" + USER2_ID + "\",\n"
-                        + "  \"name\": \"user2\"\n"
+                        + "  \"code\": \"player.found\",\n"
+                        + "  \"message\": \"Successfully found player by given ID.\",\n"
+                        + "  \"data\": {\n"
+                        + "    \"player\": {\n"
+                        + "      \"meta\": {\n"
+                        + "        \"cached_at\": 1707337378\n"
+                        + "      },\n"
+                        + "      \"username\": \"" + username + "\",\n"
+                        + "      \"id\": \"" + uuid + "\",\n"
+                        + "      \"raw_id\": \"" + id + "\",\n"
+                        + "      \"properties\": [\n"
+                        + "        {\n"
+                        + "          \"name\": \"textures\",\n"
+                        + "          \"value\": \"ewogICJ0aW1lc3RhbXAiIDogMTcwNzI5NjczMDM3NywKICAicHJvZmlsZUlkIiA6ICIwNTkxMDMwODIyOWQ0NmJiYTQ2NmU1NTc0ZGJhNDkwYyIsCiAgInByb2ZpbGVOYW1lIiA6ICJVc2VyMSIsCiAgInRleHR1cmVzIiA6IHsKICAgICJTS0lOIiA6IHsKICAgICAgInVybCIgOiAiaHR0cDovL3RleHR1cmVzLm1pbmVjcmFmdC5uZXQvdGV4dHVyZS9kOThkZGM5ZjM3NDA4YmNjMTk5YTNhYzA2Mzc3NGU1ODcwZjc3Y2NjYjJkNGMwODRmMjc3YTkxYTM3ZDU1YzIyIgogICAgfQogIH0KfQ==\"\n"
+                        + "        }\n"
+                        + "      ],\n"
+                        + "      \"name_history\": [\n"
+                        + "\n"
+                        + "      ]\n"
+                        + "    }\n"
+                        + "  },\n"
+                        + "  \"success\": true\n"
                         + "}")
             )
         );


### PR DESCRIPTION
Was starting to see 429's from Mojang's user lookup API. With this change the provider can be switched via `USER_API_PROVIDER` env var.