### PR TITLE
paper: restore requirement of version.json metadata

### DIFF
--- a/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
+++ b/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -37,7 +36,6 @@ import reactor.core.scheduler.Schedulers;
 @Slf4j
 public class InstallPaperCommand implements Callable<Integer> {
 
-    public static final String VERSION_METADATA_NAME = "version.json";
     @ArgGroup
     Inputs inputs = new Inputs();
 
@@ -166,12 +164,11 @@ public class InstallPaperCommand implements Callable<Integer> {
                 .flatMap(serverJar -> {
                     final String version;
                     try {
-                        version = Optional.ofNullable(extractVersionFromJar(serverJar))
-                                .orElseGet(() -> {
-                                    log.warn("Version metadata {} was missing from server jar: {}", VERSION_METADATA_NAME, serverJar);
-                                    return "custom";
-                                });
+                        version = extractVersionFromJar(serverJar);
 
+                        if (version == null) {
+                            return Mono.error(new GenericException("Version metadata was not available from custom server jar"));
+                        }
                     } catch (IOException e) {
                         return Mono.error(new GenericException("Failed to extract version from custom server jar", e));
                     }
@@ -191,7 +188,7 @@ public class InstallPaperCommand implements Callable<Integer> {
     }
 
     private String extractVersionFromJar(Path serverJar) throws IOException {
-        final VersionMeta versionMeta = IoStreams.readFileFromZip(serverJar, VERSION_METADATA_NAME, in ->
+        final VersionMeta versionMeta = IoStreams.readFileFromZip(serverJar, "version.json", in ->
             ObjectMappers.defaultMapper().readValue(in, VersionMeta.class)
         );
         if (versionMeta == null) {

--- a/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
+++ b/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -162,43 +163,31 @@ public class InstallPaperCommand implements Callable<Integer> {
                 .handleStatus(Fetch.loggingDownloadStatusHandler(log))
                 .assemble()
                 .publishOn(Schedulers.boundedElastic())
-                .flatMap(serverJar -> processDownloadedJar(downloadUrl, serverJar))
+                .flatMap(serverJar -> {
+                    final String version;
+                    try {
+                        version = Optional.ofNullable(extractVersionFromJar(serverJar))
+                                .orElseGet(() -> {
+                                    log.warn("Version metadata {} was missing from server jar: {}", VERSION_METADATA_NAME, serverJar);
+                                    return "custom";
+                                });
+
+                    } catch (IOException e) {
+                        return Mono.error(new GenericException("Failed to extract version from custom server jar", e));
+                    }
+                    return Mono.just(Result.builder()
+                        .serverJar(serverJar)
+                        .newManifest(
+                            PaperManifest.builder()
+                                .customDownloadUrl(downloadUrl)
+                                .files(Collections.singleton(Manifests.relativize(outputDirectory, serverJar)))
+                                .build()
+                        )
+                        .version(version)
+                        .build());
+                })
                 .block();
         }
-    }
-
-    private Mono<Result> processDownloadedJar(URI downloadUrl, Path serverJar) {
-        final String version;
-        try {
-            final String versionFromJar = extractVersionFromJar(serverJar);
-            if (versionFromJar != null) {
-                version = versionFromJar;
-            }
-            else {
-                log.warn("Version metadata {} was missing from server jar: {}", VERSION_METADATA_NAME, serverJar);
-                final String fromEnv = System.getenv("VERSION");
-                if (fromEnv != null) {
-                    version = fromEnv;
-                }
-                else {
-                    throw new GenericException("Set environment variable 'VERSION' due to missing version metadata");
-                }
-
-            }
-        } catch (IOException e) {
-            return Mono.error(new GenericException("Failed to extract version from custom server jar", e));
-        }
-
-        return Mono.just(Result.builder()
-            .serverJar(serverJar)
-            .newManifest(
-                PaperManifest.builder()
-                    .customDownloadUrl(downloadUrl)
-                    .files(Collections.singleton(Manifests.relativize(outputDirectory, serverJar)))
-                    .build()
-            )
-            .version(version)
-            .build());
     }
 
     private String extractVersionFromJar(Path serverJar) throws IOException {


### PR DESCRIPTION
Reverts #422 and #420

The custom server jar that prompted the original changes had an extraneous top level folder

<img width="420" alt="image" src="https://github.com/itzg/mc-image-helper/assets/988985/5b1b93d1-b77c-4605-8c15-90097276f1fe">

