### PR TITLE
Support optional --use-temp-dir in get to download to temp dir and copy, to avoid partial jar if interrupted

### DIFF
--- a/src/test/java/me/itzg/helpers/get/OutputToFileTest.java
+++ b/src/test/java/me/itzg/helpers/get/OutputToFileTest.java
@@ -230,4 +230,30 @@ class OutputToFileTest {
     assertThat(fileToDownload).hasContent("New content");
   }
 
+  @Test
+  void successfulWithTemporaryDirectory(@TempDir Path tempDir) throws MalformedURLException, IOException {
+    mock.expectRequest("GET", "/downloadsToFile.txt",
+        response()
+            .withBody("Response content to file", MediaType.TEXT_PLAIN)
+    );
+
+    final Path expectedFile = tempDir.resolve("out.txt");
+    final Path downloadingDir = tempDir.resolve("downloading");
+    Files.createDirectory(downloadingDir);
+
+    final int status =
+        new CommandLine(new GetCommand())
+            .execute(
+                "-o",
+                expectedFile.toString(),
+                "--use-temp-dir",
+                downloadingDir.toString(),
+                mock.buildMockedUrl("/downloadsToFile.txt").toString()
+            );
+
+    assertThat(status).isEqualTo(0);
+    assertThat(expectedFile).exists();
+    assertThat(expectedFile).hasContent("Response content to file");
+  }
+
 }


### PR DESCRIPTION
Hi,

This is the first draft of small change to download server jar to temp folder to address my [issue](https://github.com/itzg/docker-minecraft-server/issues/2841).

Some brief notes
- I've tried to keep it small
- Currently it only deals with the single file download. I've not added anything to the OutputToDirectoryHandler yet. Not sure if this is worthwhile but very happy to for consistency
- I've got negative tests for the new switch plus a test that it works when specifying a temporary directory
- The successful test doesn't actually verify it uses the download directory. This is doable with a file system watcher so I'd be happy to do it if you think it's worthwhile.

I'm not a java dev so very happy to receive any requests for changes from tiny to massive.

Thanks.
