### PR TITLE
neoforge: correctly handle versioning that drops the ".0"

### DIFF
--- a/src/main/java/me/itzg/helpers/forge/NeoForgeInstallerResolver.java
+++ b/src/main/java/me/itzg/helpers/forge/NeoForgeInstallerResolver.java
@@ -108,7 +108,10 @@ public class NeoForgeInstallerResolver implements InstallerResolver {
                 else {
                     if (minecraftVersion != null) {
                         // minor.patch of minecraft version != major.minor of neoforge version
-                        if (!(minecraftVersion[1].equals(parts[0]) && minecraftVersion[2].equals(parts[1]))) {
+                        final String minor = minecraftVersion[1];
+                        final String patch = minecraftVersion.length > 2 ? minecraftVersion[2] : "0";
+
+                        if (!(minor.equals(parts[0]) && patch.equals(parts[1]))) {
                             return false;
                         }
                     }
@@ -134,8 +137,9 @@ public class NeoForgeInstallerResolver implements InstallerResolver {
     private static String deriveMinecraftVersion(String result) {
         final String[] resolvedParts = splitNeoforgeVersion(result);
 
-        return String.join(".",
-            "1", resolvedParts[0], resolvedParts[1]
+        // Minecraft versions never end with ".0"...they just leave it off
+        return resolvedParts[1].equals("0") ? String.join(".", "1", resolvedParts[0])
+                : String.join(".", "1", resolvedParts[0], resolvedParts[1]
         );
     }
 
@@ -147,8 +151,8 @@ public class NeoForgeInstallerResolver implements InstallerResolver {
     @NotNull
     private String[] splitMinecraftVersion() {
         final String[] parts = requestedMinecraftVersion.split("\\.", 3);
-        if (parts.length < 3) {
-            throw new GenericException("Expected at least three parts to Minecraft version: " + requestedMinecraftVersion);
+        if (parts.length < 2) {
+            throw new GenericException("Expected at least two parts to Minecraft version: " + requestedMinecraftVersion);
         }
         return parts;
     }

--- a/src/test/java/me/itzg/helpers/forge/NeoForgeInstallerResolverTest.java
+++ b/src/test/java/me/itzg/helpers/forge/NeoForgeInstallerResolverTest.java
@@ -26,7 +26,8 @@ class NeoForgeInstallerResolverTest {
             arguments("1.20.3", "beta", "1.20.3", "20.3.8-beta"),
             arguments("latest", "20.2.85-beta", "1.20.2", "20.2.85-beta"),
             arguments("latest", "20.2.88", "1.20.2", "20.2.88"),
-            arguments("1.20.1", "latest", "1.20.1", "47.1.84")
+            arguments("1.20.1", "latest", "1.20.1", "47.1.84"),
+            arguments("1.21", "beta", "1.21", "21.0.42-beta")
         );
     }
 

--- a/src/test/resources/__files/forge/neoforged-neoforge-maven-metadata.xml
+++ b/src/test/resources/__files/forge/neoforged-neoforge-maven-metadata.xml
@@ -147,6 +147,9 @@
       <version>20.2.88</version>
       <version>20.4.61-beta</version>
       <version>20.4.62-beta</version>
+      <version>20.6.119</version>
+      <version>21.0.41-beta</version>
+      <version>21.0.42-beta</version>
     </versions>
     <lastUpdated>20231228145256</lastUpdated>
   </versioning>


### PR DESCRIPTION
For https://github.com/itzg/docker-minecraft-server/issues/2934