### PR TITLE
modrinth: re-download Modrinth projects based on modified time rather than filename existence

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
@@ -235,7 +235,7 @@ public class ModrinthCommand implements Callable<Integer> {
             return fetch(URI.create(versionFile.getUrl()))
                 .userAgentCommand("modrinth")
                 .toFile(outPath)
-                .skipExisting(true)
+                .skipUpToDate(true)
                 .execute();
         } catch (IOException e) {
             throw new RuntimeException("Downloading mod file", e);


### PR DESCRIPTION
Was observed with https://modrinth.com/plugin/geyserextras/version/1.21.0-v1.1.3

[Discussed in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1263129186181189756)