### PR TITLE
fabric: retry download when IO exception

### DIFF
--- a/src/main/java/me/itzg/helpers/fabric/FabricLauncherInstaller.java
+++ b/src/main/java/me/itzg/helpers/fabric/FabricLauncherInstaller.java
@@ -65,6 +65,7 @@ public class FabricLauncherInstaller {
                                     resolvedLoaderVersion,
                                     resolvedInstallerVersion
                                 ))
+                                .checkpoint("downloadResolvedLauncher")
                         )
                 )
                 .block();


### PR DESCRIPTION
Handle build test failures [like](https://github.com/itzg/docker-minecraft-server/actions/runs/13102417838/job/36552311263?pr=3292)

```
:::::::::::: LOGS ::::::::::::::::
 Network modrinth_default  Creating
 Network modrinth_default  Created
[init] Changing ownership of /data to 1000 ...
[init] Running as uid=1000 gid=1000 with /data as 'drwxr-xr-x 2 1000 1000 4096 Feb  2 21:16 /data'
[init] Resolving type given FABRIC
[mc-image-helper] 21:16:16.710 ERROR : 'install-fabric-loader' command failed. Version is 1.40.12
reactor.core.Exceptions$ReactiveException: reactor.netty.http.client.PrematureCloseException: Connection prematurely closed DURING response
	at reactor.core.Exceptions.propagate(Exceptions.java:410)
	at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:102)
	at reactor.core.publisher.Mono.block(Mono.java:1779)
	at me.itzg.helpers.fabric.FabricLauncherInstaller.installUsingVersions(FabricLauncherInstaller.java:70)
	at me.itzg.helpers.fabric.InstallFabricLoaderCommand.call(InstallFabricLoaderCommand.java:93)
	at me.itzg.helpers.fabric.InstallFabricLoaderCommand.call(InstallFabricLoaderCommand.java:15)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at me.itzg.helpers.McImageHelper.main(McImageHelper.java:176)
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
		... 13 common frames omitted
Caused by: reactor.netty.http.client.PrematureCloseException: Connection prematurely closed DURING response
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Fetching file into directory
	*__checkpoint ⇢ Fetch HEAD of requested file
Original Stack Trace:
Error: [ERROR] Failed to installFabric launcher given 1.19.1, LATEST, LATEST
```