### PR TITLE
Fix #385 with gradle toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,9 @@ jar {
 }
 
 java {
+  // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 8
   sourceCompatibility = JavaVersion.VERSION_1_8
+  toolchain.languageVersion = JavaLanguageVersion.of(21)
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,6 @@ dependencies {
   annotationProcessor "info.picocli:picocli-codegen:${picocliVersion}"
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-}
-
 compileJava {
   options.encoding = 'utf-8'
 }


### PR DESCRIPTION
Issue: #385 

Saw the open issue and thought it would be low hanging fruit, gradle toolchain setup to match the current java version used by github action. 

Also removed a duplicate source compatibility setting from build.gradle