### PR TITLE
fabric: accept shared fetch/netty arguments

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -962,7 +962,7 @@ public class CurseForgeInstaller {
         final FabricLauncherInstaller installer = new FabricLauncherInstaller(outputDir)
             .setResultsFile(resultsFile)
             .setForceReinstall(forceReinstallModloader);
-        installer.installUsingVersions(minecraftVersion, loaderVersion, null);
+        installer.installUsingVersions(sharedFetchOptions, minecraftVersion, loaderVersion, null);
     }
 
     private void prepareForge(SharedFetch sharedFetch, String minecraftVersion, String loaderVersion) {

--- a/src/main/java/me/itzg/helpers/fabric/FabricLauncherInstaller.java
+++ b/src/main/java/me/itzg/helpers/fabric/FabricLauncherInstaller.java
@@ -43,11 +43,11 @@ public class FabricLauncherInstaller {
     private boolean forceReinstall;
 
     public void installUsingVersions(
-        @NonNull String minecraftVersion,
+        Options sharedFetchOptions, @NonNull String minecraftVersion,
         @Nullable String loaderVersion,
         @Nullable String installerVersion
     ) {
-        try (SharedFetch sharedFetch = sharedFetch("fabric", Options.builder().build())) {
+        try (SharedFetch sharedFetch = sharedFetch("fabric", sharedFetchOptions)) {
             final FabricMetaClient fabricMetaClient = new FabricMetaClient(sharedFetch, fabricMetaBaseUrl);
 
             fabricMetaClient.resolveMinecraftVersion(minecraftVersion)
@@ -156,9 +156,9 @@ public class FabricLauncherInstaller {
         return Mono.just(newManifest);
     }
 
-    public void installUsingUri(URI loaderUri) throws IOException {
+    public void installUsingUri(Options sharedFetchOptions, URI loaderUri) throws IOException {
         final Path launcherPath;
-        try (SharedFetch sharedFetch = sharedFetch("fabric", Options.builder().build())) {
+        try (SharedFetch sharedFetch = sharedFetch("fabric", sharedFetchOptions)) {
             launcherPath = sharedFetch.fetch(loaderUri)
                 .toDirectory(outputDir)
                 .skipUpToDate(true)

--- a/src/main/java/me/itzg/helpers/fabric/InstallFabricLoaderCommand.java
+++ b/src/main/java/me/itzg/helpers/fabric/InstallFabricLoaderCommand.java
@@ -6,6 +6,7 @@ import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.files.ResultsFileWriter;
+import me.itzg.helpers.http.SharedFetchArgs;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
@@ -29,6 +30,9 @@ public class InstallFabricLoaderCommand implements Callable<Integer> {
 
     @ArgGroup
     OriginOptions originOptions = new OriginOptions();
+
+    @ArgGroup(exclusive = false)
+    SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
     static class OriginOptions {
         @ArgGroup(exclusive = false)
@@ -84,13 +88,14 @@ public class InstallFabricLoaderCommand implements Callable<Integer> {
             .setResultsFile(resultsFile);
 
         if (originOptions.fromUri != null) {
-            installer.installUsingUri(originOptions.fromUri);
+            installer.installUsingUri(sharedFetchArgs.options(), originOptions.fromUri);
         }
         else if (originOptions.launcherFile != null) {
             installer.installUsingLocalFile(originOptions.launcherFile);
         }
         else {
             installer.installUsingVersions(
+                sharedFetchArgs.options(),
                 originOptions.versionOptions.minecraftVersion,
                 originOptions.versionOptions.loaderVersion,
                 originOptions.versionOptions.installerVersion

--- a/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
@@ -34,7 +34,7 @@ public class SharedFetchArgs {
         optionsBuilder.tlsHandshakeTimeout(timeout);
     }
 
-    @Option(names = "--connection-pool-max-idle-timeout", defaultValue = "${env:FETCH_CONNECTION_POOL_MAX_IDLE_TIMEOUT}",
+    @Option(names = "--connection-pool-max-idle-timeout", defaultValue = "${env:FETCH_CONNECTION_POOL_MAX_IDLE_TIMEOUT:-PT15S}",
         paramLabel = "DURATION"
     )
     public void setConnectionPoolMaxIdleTimeout(Duration timeout) {

--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
@@ -254,7 +254,7 @@ public class ModrinthPackInstaller {
         new FabricLauncherInstaller(this.outputDirectory)
             .setResultsFile(this.resultsFile)
             .installUsingVersions(
-                minecraftVersion,
+                sharedFetchOpts, minecraftVersion,
                 fabricVersion,
                 null
             );

--- a/src/test/java/me/itzg/helpers/fabric/FabricLauncherInstallerTest.java
+++ b/src/test/java/me/itzg/helpers/fabric/FabricLauncherInstallerTest.java
@@ -14,6 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import me.itzg.helpers.files.Manifests;
+import me.itzg.helpers.http.SharedFetch.Options;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,7 +59,7 @@ class FabricLauncherInstallerTest {
             .setResultsFile(resultsFile);
         installer.setFabricMetaBaseUrl(wmRuntimeInfo.getHttpBaseUrl());
 
-        installer.installUsingVersions("1.19.3", null, null);
+        installer.installUsingVersions(buildSharedFetchOptions(), "1.19.3", null, null);
 
         final Path expectedLauncherPath = tempDir.resolve("fabric-server-mc.1.19.3-loader.0.14.12-launcher.0.11.1.jar");
         assertThat(expectedLauncherPath)
@@ -84,6 +85,10 @@ class FabricLauncherInstallerTest {
             .at("/files").isArrayContaining("fabric-server-mc.1.19.3-loader.0.14.12-launcher.0.11.1.jar");
     }
 
+    private Options buildSharedFetchOptions() {
+        return Options.builder().build();
+    }
+
     @Test
     void testWithProvidedUri(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         stubFor(
@@ -104,7 +109,7 @@ class FabricLauncherInstallerTest {
             .setResultsFile(expectedResultsPath);
         final URI loaderUri = URI.create(wmRuntimeInfo.getHttpBaseUrl() + "/fabric-launcher.jar");
 
-        installer.installUsingUri(loaderUri);
+        installer.installUsingUri(Options.builder().build(), loaderUri);
 
         final Path expectedLauncherPath = tempDir.resolve("fabric-launcher.jar");
         assertThat(expectedLauncherPath)
@@ -139,7 +144,7 @@ class FabricLauncherInstallerTest {
 
         final FabricLauncherInstaller installer = new FabricLauncherInstaller(tempDir);
         installer.installUsingUri(
-            URI.create(wmRuntimeInfo.getHttpBaseUrl() + "/server")
+            Options.builder().build(), URI.create(wmRuntimeInfo.getHttpBaseUrl() + "/server")
         );
 
         final Path expectedLauncherPath = tempDir.resolve("fabric-server-mc.1.19.3-loader.0.14.12-launcher.0.11.1.jar");
@@ -178,7 +183,7 @@ class FabricLauncherInstallerTest {
         installer.setFabricMetaBaseUrl(wmRuntimeInfo.getHttpBaseUrl());
 
         installer.installUsingVersions(
-            "1.19.2", null, null
+            buildSharedFetchOptions(), "1.19.2", null, null
         );
 
         final Path expectedLauncher192 = tempDir.resolve("fabric-server-mc.1.19.2-loader.0.14.12-launcher.0.11.1.jar");
@@ -189,7 +194,7 @@ class FabricLauncherInstallerTest {
         // Now upgrade from 1.19.2 to 1.19.3
 
         installer.installUsingVersions(
-            "1.19.3", null, null
+            buildSharedFetchOptions(), "1.19.3", null, null
         );
 
         final Path expectedLauncher193 = tempDir.resolve("fabric-server-mc.1.19.3-loader.0.14.12-launcher.0.11.1.jar");
@@ -212,7 +217,7 @@ class FabricLauncherInstallerTest {
         installer.setFabricMetaBaseUrl(wmRuntimeInfo.getHttpBaseUrl());
 
         installer.installUsingVersions(
-            "1.19.2", null, null
+            buildSharedFetchOptions(), "1.19.2", null, null
         );
 
         wm.verifyThat(
@@ -234,7 +239,7 @@ class FabricLauncherInstallerTest {
         wm.resetRequests();
 
         installer.installUsingVersions(
-            "1.19.2", "0.14.12", "0.11.1"
+            buildSharedFetchOptions(), "1.19.2", "0.14.12", "0.11.1"
         );
 
         assertThat(expectedLauncher192)
@@ -253,6 +258,6 @@ class FabricLauncherInstallerTest {
             .setResultsFile(resultsFile);
         installer.setFabricMetaBaseUrl("http://localhost:8080");
 
-        installer.installUsingVersions("1.19.3", null, null);
+        installer.installUsingVersions(buildSharedFetchOptions(), "1.19.3", null, null);
     }
 }


### PR DESCRIPTION
[From Discord](https://discord.com/channels/660567679458869252/660567682751528981/1360484392916484208)

Also
- default `FETCH_CONNECTION_POOL_MAX_IDLE_TIMEOUT` to 15s referring to https://projectreactor.io/docs/netty/release/reference/faq.html#faq.connection-closed

```
[init] Resolving type given FABRIC
[mc-image-helper] 05:14:00.972 ERROR : 'install-fabric-loader' command failed. Version is 1.41.6
reactor.core.Exceptions$RetryExhaustedException: Retries exhausted: 5/5
	at reactor.core.Exceptions.retryExhausted(Exceptions.java:308)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ downloadLauncher
	*__checkpoint ⇢ downloadResolvedLauncher
Original Stack Trace:
		at reactor.core.Exceptions.retryExhausted(Exceptions.java:308)
		at reactor.util.retry.RetryBackoffSpec.lambda$static$0(RetryBackoffSpec.java:68)
		at reactor.util.retry.RetryBackoffSpec.lambda$generateCompanion$4(RetryBackoffSpec.java:608)
		at reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onNext(FluxConcatMapNoPrefetch.java:183)
		at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onNext(FluxContextWrite.java:107)
		at reactor.core.publisher.SinkManyEmitterProcessor.drain(SinkManyEmitterProcessor.java:476)
		at reactor.core.publisher.SinkManyEmitterProcessor.tryEmitNext(SinkManyEmitterProcessor.java:273)
		at reactor.core.publisher.SinkManySerialized.tryEmitNext(SinkManySerialized.java:100)
		at reactor.core.publisher.InternalManySink.emitNext(InternalManySink.java:27)
		at reactor.core.publisher.FluxRetryWhen$RetryWhenMainSubscriber.onError(FluxRetryWhen.java:194)
		at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.onError(MonoSubscribeOn.java:152)
		at reactor.core.publisher.MonoFlatMap$FlatMapMain.secondError(MonoFlatMap.java:241)
		at reactor.core.publisher.MonoFlatMap$FlatMapInner.onError(MonoFlatMap.java:315)
		at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onError(FluxContextWrite.java:121)
		at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
		at reactor.core.publisher.FluxDefaultIfEmpty$DefaultIfEmptySubscriber.onError(FluxDefaultIfEmpty.java:156)
		at reactor.core.publisher.MonoFlatMap$FlatMapMain.secondError(MonoFlatMap.java:241)
		at reactor.core.publisher.MonoFlatMap$FlatMapInner.onError(MonoFlatMap.java:315)
		at reactor.core.publisher.MonoTakeLastOne$TakeLastOneSubscriber.onError(MonoTakeLastOne.java:134)
		at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onError(MonoFlatMapMany.java:256)
		at reactor.core.publisher.FluxContextWrite$ContextWriteSubscriber.onError(FluxContextWrite.java:121)
		at reactor.core.publisher.FluxDoFinally$DoFinallySubscriber.onError(FluxDoFinally.java:119)
		at reactor.core.publisher.FluxMapFuseable$MapFuseableConditionalSubscriber.onError(FluxMapFuseable.java:340)
		at reactor.core.publisher.FluxHide$SuppressFuseableSubscriber.onError(FluxHide.java:142)
		at reactor.core.publisher.MonoSubscribeOn$SubscribeOnSubscriber.onError(MonoSubscribeOn.java:152)
		at reactor.core.publisher.MonoStreamCollector$StreamCollectorSubscriber.onError(MonoStreamCollector.java:149)
		at reactor.core.publisher.FluxPeek$PeekSubscriber.onError(FluxPeek.java:222)
		at reactor.core.publisher.FluxFlatMap$FlatMapMain.checkTerminated(FluxFlatMap.java:846)
		at reactor.core.publisher.FluxFlatMap$FlatMapMain.drainLoop(FluxFlatMap.java:612)
		at reactor.core.publisher.FluxFlatMap$FlatMapMain.drain(FluxFlatMap.java:592)
		at reactor.core.publisher.FluxFlatMap$FlatMapMain.onError(FluxFlatMap.java:455)
		at reactor.core.publisher.FluxHandle$HandleSubscriber.onError(FluxHandle.java:213)
		at reactor.core.publisher.FluxMap$MapConditionalSubscriber.onError(FluxMap.java:265)
		at reactor.netty.channel.FluxReceive.terminateReceiver(FluxReceive.java:478)
		at reactor.netty.channel.FluxReceive.drainReceiver(FluxReceive.java:273)
		at reactor.netty.channel.FluxReceive.onInboundError(FluxReceive.java:466)
		at reactor.netty.channel.ChannelOperations.onInboundError(ChannelOperations.java:526)
		at reactor.netty.http.client.HttpClientOperations.onInboundClose(HttpClientOperations.java:349)
		at reactor.netty.channel.ChannelOperationsHandler.channelInactive(ChannelOperationsHandler.java:73)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:303)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
		at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:81)
		at io.netty.handler.timeout.IdleStateHandler.channelInactive(IdleStateHandler.java:280)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:303)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
		at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelInactive(CombinedChannelDuplexHandler.java:418)
		at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:377)
		at io.netty.handler.codec.http.HttpClientCodec$Decoder.channelInactive(HttpClientCodec.java:410)
		at io.netty.channel.CombinedChannelDuplexHandler.channelInactive(CombinedChannelDuplexHandler.java:221)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:303)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
		at io.netty.handler.codec.ByteToMessageDecoder.channelInputClosed(ByteToMessageDecoder.java:412)
		at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:377)
		at io.netty.handler.ssl.SslHandler.channelInactive(SslHandler.java:1191)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:303)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
		at io.netty.channel.AbstractChannelHandlerContext.fireChannelInactive(AbstractChannelHandlerContext.java:274)
		at io.netty.channel.DefaultChannelPipeline$HeadContext.channelInactive(DefaultChannelPipeline.java:1352)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:301)
		at io.netty.channel.AbstractChannelHandlerContext.invokeChannelInactive(AbstractChannelHandlerContext.java:281)
		at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:850)
		at io.netty.channel.AbstractChannel$AbstractUnsafe$7.run(AbstractChannel.java:811)
		at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
		at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
		at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
		at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405)
		at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
		at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
		at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
		at java.base/java.lang.Thread.run(Unknown Source)
	Suppressed: java.lang.Exception: #block terminated with an error
		at reactor.core.publisher.BlockingSingleSubscriber.blockingGet(BlockingSingleSubscriber.java:104)
		at reactor.core.publisher.Mono.block(Mono.java:1779)
		at me.itzg.helpers.fabric.FabricLauncherInstaller.installUsingVersions(FabricLauncherInstaller.java:71)
		at me.itzg.helpers.fabric.InstallFabricLoaderCommand.call(InstallFabricLoaderCommand.java:93)
		at me.itzg.helpers.fabric.InstallFabricLoaderCommand.call(InstallFabricLoaderCommand.java:15)
		at picocli.CommandLine.executeUserObject(CommandLine.java:2045)
		at picocli.CommandLine.access$1500(CommandLine.java:148)
		at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2465)
		at picocli.CommandLine$RunLast.handle(CommandLine.java:2457)
		at picocli.CommandLine$RunLast.handle(CommandLine.java:2419)
		at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
		at picocli.CommandLine$RunLast.execute(CommandLine.java:2421)
		at picocli.CommandLine.execute(CommandLine.java:2174)
		at me.itzg.helpers.McImageHelper.main(McImageHelper.java:178)
Caused by: reactor.netty.http.client.PrematureCloseException: Connection prematurely closed DURING response
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Error has been observed at the following site(s):
	*__checkpoint ⇢ Fetching file into directory
	*__checkpoint ⇢ Fetch HEAD of requested file
```