### PR TITLE
Add -O option to mcopy command

### DIFF
--- a/src/main/java/me/itzg/helpers/http/OutputToDirectoryFetchBuilder.java
+++ b/src/main/java/me/itzg/helpers/http/OutputToDirectoryFetchBuilder.java
@@ -4,17 +4,19 @@ import static io.netty.handler.codec.http.HttpHeaderNames.IF_MODIFIED_SINCE;
 import static io.netty.handler.codec.http.HttpHeaderNames.LAST_MODIFIED;
 import static java.util.Objects.requireNonNull;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.files.ReactiveFileUtils;
-import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.ByteBufFlux;
@@ -32,6 +34,9 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
 
     @Setter
     private boolean skipUpToDate;
+
+    @Setter
+    private boolean useRemoteName;
 
     private FileDownloadStatusHandler statusHandler = (status, uri, file) -> {
     };
@@ -63,12 +68,15 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
 
     public Path execute() throws IOException {
         return assemble()
-            .block();
+                .block();
     }
 
     public Mono<Path> assemble() {
-        return useReactiveClient(client ->
-            client
+        if (useRemoteName) {
+            return assembleWithRemoteName();
+        }
+
+        return useReactiveClient(client -> client
                 .headers(this::applyHeaders)
                 .followRedirect(true)
                 .doOnRequest(debugLogRequest(log, "file head fetch"))
@@ -87,35 +95,74 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
                     final Instant lastModified = respLastModified(resp);
 
                     return assembleFileDownload(client, outputFile,
-                        lastModified,
-                        resp.resourceUrl()
-                    );
+                            lastModified,
+                            resp.resourceUrl());
                 })
                 .subscribeOn(Schedulers.boundedElastic())
-                .checkpoint("Fetch HEAD of requested file")
-        );
+                .checkpoint("Fetch HEAD of requested file"));
+    }
+
+    private Mono<Path> assembleWithRemoteName() {
+        return useReactiveClient(client -> {
+            final String path = uri().getPath();
+            final int pos = path.lastIndexOf('/');
+            String filename = path.substring(pos + 1);
+
+            // Strip query parameters and fragments from the filename
+            int queryPos = filename.indexOf('?');
+            if (queryPos > 0) {
+                filename = filename.substring(0, queryPos);
+            }
+
+            int fragmentPos = filename.indexOf('#');
+            if (fragmentPos > 0) {
+                filename = filename.substring(0, fragmentPos);
+            }
+
+            final Path outputFile = outputDirectory.resolve(filename);
+
+            return client
+                    .headers(this::applyHeaders)
+                    .followRedirect(true)
+                    .doOnRequest(debugLogRequest(log, "file get fetch"))
+                    .get()
+                    .uri(uri())
+                    .response((resp, byteBufFlux) -> {
+                        if (notSuccess(resp)) {
+                            return failedRequestMono(resp, byteBufFlux.aggregate(), "Getting file");
+                        }
+
+                        statusHandler.call(FileDownloadStatus.DOWNLOADING, uri(), outputFile);
+
+                        return skipExisting(resp, outputFile)
+                                .flatMap(skip -> skip ? Mono.just(outputFile)
+                                        : copyBodyInputStreamToFile(byteBufFlux, outputFile));
+                    })
+                    .last()
+                    .subscribeOn(Schedulers.boundedElastic())
+                    .checkpoint("Direct file download with remote name");
+        });
     }
 
     private Mono<Path> assembleFileDownloadNameViaGet(HttpClient client) {
         return client
-            .followRedirect(true)
-            .doOnRequest(debugLogRequest(log, "file get fetch"))
-            .get()
-            .uri(uri())
-            .response((resp, byteBufFlux) -> {
-                if (notSuccess(resp)) {
-                    return failedRequestMono(resp, byteBufFlux.aggregate(), "Getting file");
-                }
+                .followRedirect(true)
+                .doOnRequest(debugLogRequest(log, "file get fetch"))
+                .get()
+                .uri(uri())
+                .response((resp, byteBufFlux) -> {
+                    if (notSuccess(resp)) {
+                        return failedRequestMono(resp, byteBufFlux.aggregate(), "Getting file");
+                    }
 
-                final Path outputFile = outputDirectory.resolve(extractFilename(resp));
-                statusHandler.call(FileDownloadStatus.DOWNLOADING, uri(), outputFile);
+                    final Path outputFile = outputDirectory.resolve(extractFilename(resp));
+                    statusHandler.call(FileDownloadStatus.DOWNLOADING, uri(), outputFile);
 
-                return skipExisting(resp, outputFile)
-                    .flatMap(skip -> skip ? Mono.just(outputFile)
-                        : copyBodyInputStreamToFile(byteBufFlux, outputFile)
-                    );
-            })
-            .last();
+                    return skipExisting(resp, outputFile)
+                            .flatMap(skip -> skip ? Mono.just(outputFile)
+                                    : copyBodyInputStreamToFile(byteBufFlux, outputFile));
+                })
+                .last();
     }
 
     private Instant respLastModified(HttpClientResponse resp) {
@@ -129,35 +176,34 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
      */
     private Mono<Boolean> skipExisting(HttpClientResponse resp, @NotNull Path outputFile) {
         return ReactiveFileUtils.fileExists(outputFile)
-            .flatMap(exists -> {
-                if (!exists) {
+                .flatMap(exists -> {
+                    if (!exists) {
+                        return Mono.just(false);
+                    }
+
+                    if (skipExisting && !skipUpToDate) {
+                        log.debug("The file {} already exists", outputFile);
+                        statusHandler.call(FileDownloadStatus.SKIP_FILE_EXISTS, uri(), outputFile);
+                        return Mono.just(true);
+                    } else if (skipUpToDate) {
+
+                        return ReactiveFileUtils.getLastModifiedTime(outputFile)
+                                .mapNotNull(outputLastModified -> {
+                                    final Instant headerLastModified = respLastModified(resp);
+                                    if (isFileUpToDate(outputLastModified, headerLastModified)) {
+                                        log.debug(
+                                                "The file={} lastModified={} is already up to date compared to response={}",
+                                                outputFile, outputLastModified, headerLastModified);
+                                        statusHandler.call(FileDownloadStatus.SKIP_FILE_UP_TO_DATE, uri(), outputFile);
+                                        return true;
+                                    }
+
+                                    return false;
+                                });
+                    }
+
                     return Mono.just(false);
-                }
-
-                if (skipExisting && !skipUpToDate) {
-                    log.debug("The file {} already exists", outputFile);
-                    statusHandler.call(FileDownloadStatus.SKIP_FILE_EXISTS, uri(), outputFile);
-                    return Mono.just(true);
-                }
-                else if (skipUpToDate) {
-
-                    return ReactiveFileUtils.getLastModifiedTime(outputFile)
-                        .mapNotNull(outputLastModified -> {
-                            final Instant headerLastModified = respLastModified(resp);
-                            if (isFileUpToDate(outputLastModified, headerLastModified)) {
-                                log.debug("The file={} lastModified={} is already up to date compared to response={}",
-                                    outputFile, outputLastModified, headerLastModified
-                                );
-                                statusHandler.call(FileDownloadStatus.SKIP_FILE_UP_TO_DATE, uri(), outputFile);
-                                return true;
-                            }
-
-                            return false;
-                        });
-                }
-
-                return Mono.just(false);
-            });
+                });
 
     }
 
@@ -165,89 +211,82 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
         return headerLastModified != null && headerLastModified.compareTo(fileLastModified) <= 0;
     }
 
-    private Mono<Path> assembleFileDownload(HttpClient client, Path outputFile, Instant headerLastModified, String resourceUrl) {
+    private Mono<Path> assembleFileDownload(HttpClient client, Path outputFile, Instant headerLastModified,
+            String resourceUrl) {
         final Mono<Instant> fileLastModifiedMono = ReactiveFileUtils.getLastModifiedTime(outputFile);
 
         final Mono<Boolean> alreadyUpToDateMono;
         if (skipExisting && !skipUpToDate) {
 
             alreadyUpToDateMono = ReactiveFileUtils.fileExists(outputFile)
-                .doOnNext(exists -> {
-                    if (exists) {
-                        log.debug("The file {} already exists", outputFile);
-                        statusHandler.call(FileDownloadStatus.SKIP_FILE_EXISTS, uri(), outputFile);
-                    }
-                });
-        }
-        else if (skipUpToDate) {
+                    .doOnNext(exists -> {
+                        if (exists) {
+                            log.debug("The file {} already exists", outputFile);
+                            statusHandler.call(FileDownloadStatus.SKIP_FILE_EXISTS, uri(), outputFile);
+                        }
+                    });
+        } else if (skipUpToDate) {
 
-            alreadyUpToDateMono =
-                fileLastModifiedMono
+            alreadyUpToDateMono = fileLastModifiedMono
                     .map(fileLastModified -> {
                         final boolean fileUpToDate = isFileUpToDate(fileLastModified, headerLastModified);
                         if (fileUpToDate) {
                             log.debug("The file={} lastModified={} is already up to date compared to response={}",
-                                outputFile, fileLastModified, headerLastModified
-                            );
+                                    outputFile, fileLastModified, headerLastModified);
                             statusHandler.call(FileDownloadStatus.SKIP_FILE_UP_TO_DATE, uri(), outputFile);
                         }
                         return fileUpToDate;
                     })
                     .defaultIfEmpty(false);
-        }
-        else {
+        } else {
 
             alreadyUpToDateMono = Mono.just(false);
         }
 
         return alreadyUpToDateMono
-            .filter(alreadyUpToDate -> !alreadyUpToDate)
-            .flatMap(notUsed -> client
-                .headers(this::applyHeaders)
-                .headersWhen(headers ->
-                    skipUpToDate ?
-                        fileLastModifiedMono
-                            .map(outputLastModified -> headers.set(
-                                IF_MODIFIED_SINCE,
-                                httpDateTimeFormatter.format(outputLastModified)
-                            ))
-                            .defaultIfEmpty(headers)
-                        : Mono.just(headers)
-                )
-                .followRedirect(true)
-                .doOnRequest(debugLogRequest(log, "file fetch"))
-                .doOnRequest(
-                    (httpClientRequest, connection) -> statusHandler.call(FileDownloadStatus.DOWNLOADING, uri(), outputFile))
-                .get()
-                .uri(resourceUrl)
-                .response((resp, byteBufFlux) -> {
-                    if (skipUpToDate && resp.status() == HttpResponseStatus.NOT_MODIFIED) {
-                        log.debug("The file {} is already up to date", outputFile);
-                        statusHandler.call(FileDownloadStatus.SKIP_FILE_UP_TO_DATE, uri(), outputFile);
-                        return Mono.just(outputFile);
-                    }
+                .filter(alreadyUpToDate -> !alreadyUpToDate)
+                .flatMap(notUsed -> client
+                        .headers(this::applyHeaders)
+                        .headersWhen(headers -> skipUpToDate ? fileLastModifiedMono
+                                .map(outputLastModified -> headers.set(
+                                        IF_MODIFIED_SINCE,
+                                        httpDateTimeFormatter.format(outputLastModified)))
+                                .defaultIfEmpty(headers)
+                                : Mono.just(headers))
+                        .followRedirect(true)
+                        .doOnRequest(debugLogRequest(log, "file fetch"))
+                        .doOnRequest(
+                                (httpClientRequest, connection) -> statusHandler.call(FileDownloadStatus.DOWNLOADING,
+                                        uri(), outputFile))
+                        .get()
+                        .uri(resourceUrl)
+                        .response((resp, byteBufFlux) -> {
+                            if (skipUpToDate && resp.status() == HttpResponseStatus.NOT_MODIFIED) {
+                                log.debug("The file {} is already up to date", outputFile);
+                                statusHandler.call(FileDownloadStatus.SKIP_FILE_UP_TO_DATE, uri(), outputFile);
+                                return Mono.just(outputFile);
+                            }
 
-                    if (notSuccess(resp)) {
-                        return failedRequestMono(resp, byteBufFlux.aggregate(), "Downloading file");
-                    }
+                            if (notSuccess(resp)) {
+                                return failedRequestMono(resp, byteBufFlux.aggregate(), "Downloading file");
+                            }
 
-                    return copyBodyInputStreamToFile(byteBufFlux, outputFile);
-                })
-                .last()
-                .checkpoint("Fetching file into directory")
-            )
-            .defaultIfEmpty(outputFile);
+                            return copyBodyInputStreamToFile(byteBufFlux, outputFile);
+                        })
+                        .last()
+                        .checkpoint("Fetching file into directory"))
+                .defaultIfEmpty(outputFile);
     }
 
     private Mono<Path> copyBodyInputStreamToFile(ByteBufFlux byteBufFlux, Path outputFile) {
         log.trace("Copying response body to file={}", outputFile);
 
         return ReactiveFileUtils.copyByteBufFluxToFile(byteBufFlux, outputFile)
-            .map(fileSize -> {
-                statusHandler.call(FileDownloadStatus.DOWNLOADED, uri(), outputFile);
-                downloadedHandler.call(uri(), outputFile, fileSize);
-                return outputFile;
-            });
+                .map(fileSize -> {
+                    statusHandler.call(FileDownloadStatus.DOWNLOADED, uri(), outputFile);
+                    downloadedHandler.call(uri(), outputFile, fileSize);
+                    return outputFile;
+                });
     }
 
     private String extractFilename(HttpClientResponse resp) {

--- a/src/main/java/me/itzg/helpers/sync/MulitCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MulitCopyCommand.java
@@ -13,6 +13,10 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+
+import org.jetbrains.annotations.Blocking;
+import org.reactivestreams.Publisher;
+
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidParameterException;
@@ -20,8 +24,6 @@ import me.itzg.helpers.files.Manifests;
 import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.Uris;
-import org.jetbrains.annotations.Blocking;
-import org.reactivestreams.Publisher;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
@@ -31,42 +33,39 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 @Command(name = "mcopy", description = "Multi-source file copy operation with with managed cleanup. "
-    + "Supports auto-detected sourcing from file list, directories, and URLs")
+        + "Supports auto-detected sourcing from file list, directories, and URLs")
 @Slf4j
 public class MulitCopyCommand implements Callable<Integer> {
-    @Option(names = {"--help", "-h"}, usageHelp = true)
+    @Option(names = { "--help", "-h" }, usageHelp = true)
     boolean showHelp;
 
-    @Option(names = {"--manifest-id", "--scope"},
-        description = "If managed cleanup is required, this is the identifier used for qualifying manifest filename in destination"
-    )
+    @Option(names = { "--manifest-id",
+            "--scope" }, description = "If managed cleanup is required, this is the identifier used for qualifying manifest filename in destination")
     String manifestId;
 
-    @Option(names = {"--to", "--output-directory"}, required = true)
+    @Option(names = { "--to", "--output-directory" }, required = true)
     Path dest;
 
-    @Option(names = "--glob", defaultValue = "*", paramLabel = "GLOB",
-        description = "When a source is a directory, this filename glob will be applied to select files."
-    )
+    @Option(names = "--glob", defaultValue = "*", paramLabel = "GLOB", description = "When a source is a directory, this filename glob will be applied to select files.")
     String fileGlob;
 
-    @Option(names = "--file-is-listing",
-        description = "Source files or URLs are processed as a line delimited list of sources.\n" +
-            "For remote listing files, the contents must all be file URLs."
-    )
+    @Option(names = "--file-is-listing", description = "Source files or URLs are processed as a line delimited list of sources.\n"
+            +
+            "For remote listing files, the contents must all be file URLs.")
     boolean fileIsListingOption;
 
-    @Option(names = {"--skip-up-to-date", "-z"}, defaultValue = "true")
+    @Option(names = { "--skip-up-to-date", "-z" }, defaultValue = "true")
     boolean skipUpToDate;
 
     @Option(names = "--skip-existing", defaultValue = "false")
     boolean skipExisting;
 
-    @Parameters(split = SPLIT_COMMA_NL, splitSynopsisLabel = SPLIT_SYNOPSIS_COMMA_NL, arity = "1..*",
-        paramLabel = "SRC",
-        description = "Any mix of source file, directory, or URLs."
-            + "%nCan be optionally comma or newline separated."
-    )
+    @Option(names = { "--remote-name",
+            "-O" }, description = "Use the filename from the URL directly instead of doing a HEAD request to determine the filename.")
+    boolean useRemoteName;
+
+    @Parameters(split = SPLIT_COMMA_NL, splitSynopsisLabel = SPLIT_SYNOPSIS_COMMA_NL, arity = "1..*", paramLabel = "SRC", description = "Any mix of source file, directory, or URLs."
+            + "%nCan be optionally comma or newline separated.")
     List<String> sources;
 
     @Override
@@ -75,34 +74,34 @@ public class MulitCopyCommand implements Callable<Integer> {
         Files.createDirectories(dest);
 
         Flux.fromIterable(sources)
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .flatMap(source -> processSource(source, fileIsListingOption))
-            .collectList()
-            .flatMap(this::cleanupAndSaveManifest)
-            .block();
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .flatMap(source -> processSource(source, fileIsListingOption))
+                .collectList()
+                .flatMap(this::cleanupAndSaveManifest)
+                .block();
 
         return ExitCode.OK;
     }
 
     private Mono<?> cleanupAndSaveManifest(List<Path> paths) {
         return Mono.justOrEmpty(manifestId)
-            .publishOn(Schedulers.boundedElastic())
-            .map(s -> {
-                final MultiCopyManifest prevManifest = Manifests.load(dest, manifestId, MultiCopyManifest.class);
+                .publishOn(Schedulers.boundedElastic())
+                .map(s -> {
+                    final MultiCopyManifest prevManifest = Manifests.load(dest, manifestId, MultiCopyManifest.class);
 
-                final MultiCopyManifest newManifest = MultiCopyManifest.builder()
-                    .files(Manifests.relativizeAll(dest, paths))
-                    .build();
+                    final MultiCopyManifest newManifest = MultiCopyManifest.builder()
+                            .files(Manifests.relativizeAll(dest, paths))
+                            .build();
 
-                try {
-                    Manifests.cleanup(dest, prevManifest, newManifest, log);
-                } catch (IOException e) {
-                    log.warn("Failed to cleanup from previous manifest");
-                }
+                    try {
+                        Manifests.cleanup(dest, prevManifest, newManifest, log);
+                    } catch (IOException e) {
+                        log.warn("Failed to cleanup from previous manifest");
+                    }
 
-                return Manifests.save(dest, manifestId, newManifest);
-            });
+                    return Manifests.save(dest, manifestId, newManifest);
+                });
     }
 
     private Publisher<Path> processSource(String source, boolean fileIsListing) {
@@ -124,27 +123,27 @@ public class MulitCopyCommand implements Callable<Integer> {
 
     private Flux<Path> processListingFile(Path listingFile) {
         return Mono.just(listingFile)
-            .publishOn(Schedulers.boundedElastic())
-            .flatMapMany(path -> {
-                try {
-                    @SuppressWarnings("BlockingMethodInNonBlockingContext") // false warning from IntelliJ
-                    final List<String> lines = Files.readAllLines(path);
-                    return Flux.fromIterable(lines)
-                        .filter(this::isListingLine)
-                        .flatMap(src -> processSource(src,
-                            // avoid recursive file-listing processing
-                            false));
-                } catch (IOException e) {
-                    return Mono.error(new GenericException("Failed to read file listing from " + path));
-                }
-            });
+                .publishOn(Schedulers.boundedElastic())
+                .flatMapMany(path -> {
+                    try {
+                        @SuppressWarnings("BlockingMethodInNonBlockingContext") // false warning from IntelliJ
+                        final List<String> lines = Files.readAllLines(path);
+                        return Flux.fromIterable(lines)
+                                .filter(this::isListingLine)
+                                .flatMap(src -> processSource(src,
+                                        // avoid recursive file-listing processing
+                                        false));
+                    } catch (IOException e) {
+                        return Mono.error(new GenericException("Failed to read file listing from " + path));
+                    }
+                });
     }
 
     private Mono<Path> processFile(Path source) {
 
         return Mono.just(source)
-            .publishOn(Schedulers.boundedElastic())
-            .map(path -> processFileImmediate(source, dest));
+                .publishOn(Schedulers.boundedElastic())
+                .map(path -> processFileImmediate(source, dest));
     }
 
     /**
@@ -165,19 +164,16 @@ public class MulitCopyCommand implements Callable<Integer> {
                 if (Files.size(source) != Files.size(destFile)) {
                     if (Files.getLastModifiedTime(source).compareTo(Files.getLastModifiedTime(destFile)) > 0) {
                         log.debug("Copying over existing={} file since source={} file is newer",
-                            destFile, source
-                        );
+                                destFile, source);
 
                         Files.copy(source, destFile, StandardCopyOption.REPLACE_EXISTING);
                     } else {
                         log.debug("Skipping existing={} since it is newer than source={}",
-                            destFile, source
-                        );
+                                destFile, source);
                     }
                 } else {
                     log.debug("Skipping existing={} since it has same size as source={}",
-                        destFile, source
-                    );
+                            destFile, source);
                 }
             } catch (IOException e) {
                 throw new GenericException("Failed to evaluate/copy existing file", e);
@@ -197,75 +193,75 @@ public class MulitCopyCommand implements Callable<Integer> {
 
     private Flux<Path> processDirectory(Path srcDir) {
         return Mono.just(srcDir)
-            .publishOn(Schedulers.boundedElastic())
-            .flatMapMany(path -> {
-                if (!Files.exists(srcDir)) {
-                    return Mono.error(new InvalidParameterException("Source directory does not exist: " + srcDir));
-                }
-                if (!Files.isDirectory(srcDir)) {
-                    return Mono.error(new InvalidParameterException("Source is not a directory: " + srcDir));
-                }
-
-                try {
-                    final ArrayList<Path> results = new ArrayList<>();
-                    //noinspection BlockingMethodInNonBlockingContext because IntelliJ is confused
-                    try (DirectoryStream<Path> files = Files.newDirectoryStream(srcDir, fileGlob)) {
-                        for (final Path file : files) {
-                            //noinspection BlockingMethodInNonBlockingContext because IntelliJ is confused
-                            results.add(processFileImmediate(file, dest));
-                        }
+                .publishOn(Schedulers.boundedElastic())
+                .flatMapMany(path -> {
+                    if (!Files.exists(srcDir)) {
+                        return Mono.error(new InvalidParameterException("Source directory does not exist: " + srcDir));
                     }
-                    return Flux.fromIterable(results);
-                } catch (IOException e) {
-                    throw new GenericException("Failed to process directory source", e);
-                }
-            });
+                    if (!Files.isDirectory(srcDir)) {
+                        return Mono.error(new InvalidParameterException("Source is not a directory: " + srcDir));
+                    }
+
+                    try {
+                        final ArrayList<Path> results = new ArrayList<>();
+                        // noinspection BlockingMethodInNonBlockingContext because IntelliJ is confused
+                        try (DirectoryStream<Path> files = Files.newDirectoryStream(srcDir, fileGlob)) {
+                            for (final Path file : files) {
+                                // noinspection BlockingMethodInNonBlockingContext because IntelliJ is confused
+                                results.add(processFileImmediate(file, dest));
+                            }
+                        }
+                        return Flux.fromIterable(results);
+                    } catch (IOException e) {
+                        throw new GenericException("Failed to process directory source", e);
+                    }
+                });
     }
 
     private Mono<Path> processRemoteSource(String source) {
-        return Fetch.fetch(URI.create(source))
-            .userAgentCommand("mcopy")
-            .toDirectory(dest)
-            .skipUpToDate(skipUpToDate)
-            .skipExisting(skipExisting)
-            .handleStatus((status, uri, file) -> {
-                switch (status) {
-                    case DOWNLOADING:
-                        log.info("Downloading {} from {}", file, uri);
-                        break;
-                    case SKIP_FILE_UP_TO_DATE:
-                        log.info("The file {} is already up to date", file);
-                        break;
-                    case SKIP_FILE_EXISTS:
-                        log.info("The file {} already exists", file);
-                        break;
-                    case DOWNLOADED:
-                        log.debug("Finished downloading to file={}", file);
-                        break;
-                }
-            })
-            .assemble()
-            .checkpoint("Retrieving " + source, true);
+        URI uri = URI.create(source);
+        return Fetch.fetch(uri)
+                .userAgentCommand("mcopy")
+                .toDirectory(dest)
+                .skipUpToDate(skipUpToDate)
+                .skipExisting(skipExisting)
+                .useRemoteName(useRemoteName)
+                .handleStatus((status, uri1, file) -> {
+                    switch (status) {
+                        case DOWNLOADING:
+                            log.info("Downloading {} from {}", file, uri1);
+                            break;
+                        case SKIP_FILE_UP_TO_DATE:
+                            log.info("The file {} is already up to date", file);
+                            break;
+                        case SKIP_FILE_EXISTS:
+                            log.info("The file {} already exists", file);
+                            break;
+                        case DOWNLOADED:
+                            log.debug("Finished downloading to file={}", file);
+                            break;
+                    }
+                })
+                .assemble()
+                .checkpoint("Retrieving " + source, true);
     }
 
     private Flux<Path> processRemoteListingFile(String source) {
         @SuppressWarnings("resource") // closed on terminate
         SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", SharedFetch.Options.builder().build());
         return Mono.just(source)
-            .flatMapMany(s ->
-                sharedFetch.fetch(URI.create(source))
-                    .asString().assemble()
-                    .flatMapMany(content -> Flux.just(content.split("\\r?\\n")))
-                    .filter(this::isListingLine)
-            )
-            .flatMap(this::processRemoteSource)
-            .doOnTerminate(sharedFetch::close)
-            .checkpoint("Processing remote listing at " + source, true);
+                .flatMapMany(s -> sharedFetch.fetch(URI.create(source))
+                        .asString().assemble()
+                        .flatMapMany(content -> Flux.just(content.split("\\r?\\n")))
+                        .filter(this::isListingLine))
+                .flatMap(this::processRemoteSource)
+                .doOnTerminate(sharedFetch::close)
+                .checkpoint("Processing remote listing at " + source, true);
     }
 
     private boolean isListingLine(String s) {
         return !s.startsWith("#")
-            && !s.isEmpty();
+                && !s.isEmpty();
     }
 
 }


### PR DESCRIPTION
Closes #549 

This PR adds a new option to the `mcopy` command:
`-O` or `--remote-name` - which does the same as the cURL param `-O`.

This basically strips off all the things after a ? or # and takes the last section of the URL to determine the filename, avoiding usage of the HEAD request (which fails on presigned S3 urls, see #549 )

I tested this method with the following URL (expires on May 5th, 2025):
<details><summary>Details</summary>
<p>

`https://nbg1.your-objectstorage.com/ziffer-artifacts-staging/builds/4e8f7980-3955-48c4-9ff9-9a8dbedcbf41/test-plugin-1.0-SNAPSHOT.jar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6OL4X4U2SMEH6AKWA71D/20250428/auto/s3/aws4_request&X-Amz-Date=20250428T135531Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=0832406b9351cda79525911df41b7f76166993eb0949e9ab4135cd07c904c64a`

</p>
</details> 

successfully. The `mcopy` command fails if -O is not provided, and succeeds if -O is provided.


(Sorry for the formatting changes, I couldn't seem to get VSCode working with the .editorconfig correctly, maybe some other Contributor could format it once with IntelliJ?)