### PR TITLE
Check for unsupported HEAD before failing request

### DIFF
--- a/src/main/java/me/itzg/helpers/http/OutputToDirectoryFetchBuilder.java
+++ b/src/main/java/me/itzg/helpers/http/OutputToDirectoryFetchBuilder.java
@@ -4,17 +4,19 @@ import static io.netty.handler.codec.http.HttpHeaderNames.IF_MODIFIED_SINCE;
 import static io.netty.handler.codec.http.HttpHeaderNames.LAST_MODIFIED;
 import static java.util.Objects.requireNonNull;
 
-import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+
+import org.jetbrains.annotations.NotNull;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.files.ReactiveFileUtils;
-import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.netty.ByteBufFlux;
@@ -75,12 +77,12 @@ public class OutputToDirectoryFetchBuilder extends FetchBuilderBase<OutputToDire
                 .head()
                 .uri(uri())
                 .responseSingle((resp, bodyMono) -> {
-                    if (notSuccess(resp)) {
-                        return failedRequestMono(resp, bodyMono, "Extracting filename");
-                    }
-
                     if (isHeadUnsupportedResponse(resp)) {
                         return assembleFileDownloadNameViaGet(client);
+                    }
+
+                    if (notSuccess(resp)) {
+                        return failedRequestMono(resp, bodyMono, "Extracting filename");
                     }
 
                     final Path outputFile = outputDirectory.resolve(extractFilename(resp));


### PR DESCRIPTION
Closes #549 

This is a new approach to handling failing HEAD requests, derived from the discussion in #550 

Basically, this PR re-orders the conditional failing of a request if the HEAD fetching did not work as expected. For example, presigned S3 URLs do not support HEAD requests and respond with a 403.

Also, `isHeadUnsupportedResponse` now returns true as well when the HEAD response was a 403. (to gracefully handle the before mentioned).

Testing with the following URL (expiring on May 5th) now works as expected (also determining the right filename):
<details><summary>Details</summary>
<p>

`https://nbg1.your-objectstorage.com/ziffer-artifacts-staging/builds/4e8f7980-3955-48c4-9ff9-9a8dbedcbf41/test-plugin-1.0-SNAPSHOT.jar?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=6OL4X4U2SMEH6AKWA71D/20250428/auto/s3/aws4_request&X-Amz-Date=20250428T135531Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=0832406b9351cda79525911df41b7f76166993eb0949e9ab4135cd07c904c64a`

</p>
</details> 
instead of failing the request early because a HEAD on this URL returns 403.