### PR TITLE
Add Modrinth project files support

### DIFF
--- a/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
@@ -397,13 +397,12 @@ class ModrinthCommandTest {
         final int exitCode = new CommandLine(
             new ModrinthCommand()
         )
-            .setExpandAtFiles(false)
             .execute(
                 "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
                 "--output-directory", tempDir.toString(),
                 "--game-version", "1.19.2",
                 "--loader", "fabric",
-                "--projects", "@" + listingFile
+                "--projects=@" + listingFile
             );
 
         assertThat(exitCode).isEqualTo(ExitCode.OK);

--- a/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
@@ -386,9 +386,9 @@ class ModrinthCommandTest {
 
         final Path listingFile = Files.write(tempDir.resolve("listing.txt"),
             Arrays.asList(
-                "fabric-api:vNBWcMLP",
+                "fabric-api",
                 "# This is a comment",
-                "cloth-config:qA00xo1O",
+                "cloth-config",
                 "",
                 "# Another comment"
             )
@@ -400,15 +400,15 @@ class ModrinthCommandTest {
             .execute(
                 "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
                 "--output-directory", tempDir.toString(),
-                "--game-version", "1.21.5",
+                "--game-version", "1.19.2",
                 "--loader", "fabric",
                 "--projects", "@" + listingFile
             );
 
         assertThat(exitCode).isEqualTo(ExitCode.OK);
 
-        assertThat(tempDir.resolve("mods/fabric-api-0.127.1+1.21.5.jar")).exists();
-        assertThat(tempDir.resolve("mods/cloth-config-18.0.145-fabric.jar")).exists();
+        assertThat(tempDir.resolve("mods/fabric-api-0.76.1+1.19.2.jar")).exists();
+        assertThat(tempDir.resolve("mods/cloth-config-8.3.103-fabric.jar")).exists();
     }
 
     @NotNull

--- a/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
@@ -397,6 +397,7 @@ class ModrinthCommandTest {
         final int exitCode = new CommandLine(
             new ModrinthCommand()
         )
+            .setExpandAtFiles(false)
             .execute(
                 "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
                 "--output-directory", tempDir.toString(),


### PR DESCRIPTION
Uses the same syntax as Curseforge: `@/path/to/modrinth-mods.txt`. Added tests to make sure it is working as expected. I tried to follow how it was done for Curseforge as closely as possible to keep things consistent. I will make a separate PR to update the docs at itzg/docker-minecraft-server/docs/mods-and-plugins/modrinth.md

docs PR: https://github.com/itzg/docker-minecraft-server/pull/3506