### PR TITLE
build(deps): bump reactor-netty to 1.2.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
   implementation 'com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39'
   implementation 'com.jayway.jsonpath:json-path:2.9.0'
   implementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
-  implementation 'io.projectreactor.netty:reactor-netty-http:1.2.8'
+  implementation 'io.projectreactor.netty:reactor-netty-http:1.2.9'
   implementation 'org.apache.maven:maven-artifact:3.9.11'
   implementation 'commons-codec:commons-codec:1.19.0'
   // for RFC5987 parsing of content-disposition filename*

--- a/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
@@ -55,6 +55,13 @@ public class SharedFetchArgs {
         optionsBuilder.useHttp2(useHttp2);
     }
 
+    @Option(names = "--wiretap", defaultValue = "${env:FETCH_WIRETAP:-false}",
+        description = "Whether to enable Reactor Netty wiretap logging. Default: ${DEFAULT-VALUE}"
+    )
+    public void setWiretap(boolean wiretap) {
+        optionsBuilder.wiretap(wiretap);
+    }
+
     public Options options() {
         return optionsBuilder.build();
     }


### PR DESCRIPTION
Also added argument to enable Reactor Netty wiretap logging

https://projectreactor.io/docs/netty/release/reference/http-client.html#_wire_logger