### PR TITLE
Alternative to #434: download via .download temp file then rename

### DIFF
--- a/src/test/java/me/itzg/helpers/get/GetCommandTest.java
+++ b/src/test/java/me/itzg/helpers/get/GetCommandTest.java
@@ -12,12 +12,9 @@ import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import me.itzg.helpers.TestLoggingAppender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 

--- a/src/test/java/me/itzg/helpers/get/OutputToFileTest.java
+++ b/src/test/java/me/itzg/helpers/get/OutputToFileTest.java
@@ -254,5 +254,99 @@ class OutputToFileTest {
     // The temporary file with .download extension should no longer exist after successful download
     assertThat(tempDir.resolve("out.txt.download")).doesNotExist();
   }
+  
+  @Test
+  void handlesExistingDownloadFile(@TempDir Path tempDir) throws MalformedURLException, IOException {
+    mock.expectRequest("GET", "/downloadsToFile.txt",
+        response()
+            .withBody("New content", MediaType.TEXT_PLAIN)
+    );
+
+    final Path expectedFile = tempDir.resolve("out.txt");
+    final Path downloadFile = tempDir.resolve("out.txt.download");
+    
+    // Create a pre-existing .download file with different content
+    Files.writeString(downloadFile, "Partial old content");
+    
+    final int status =
+        new CommandLine(new GetCommand())
+            .execute(
+                "-o",
+                expectedFile.toString(),
+                "--use-temp-file",
+                mock.buildMockedUrl("/downloadsToFile.txt").toString()
+            );
+
+    assertThat(status).isEqualTo(0);
+    assertThat(expectedFile).exists();
+    assertThat(expectedFile).hasContent("New content");
+    // The temporary file should be gone
+    assertThat(downloadFile).doesNotExist();
+  }
+  
+  @Test
+  void preservesOriginalWhenErrorOccurs(@TempDir Path tempDir) throws MalformedURLException, IOException {
+    mock.expectRequest("GET", "/errorFile.txt",
+        response()
+            .withStatusCode(500)
+            .withBody("Server error", MediaType.TEXT_PLAIN)
+    );
+
+    final Path expectedFile = tempDir.resolve("out.txt");
+    final String originalContent = "Original content that should be preserved";
+    
+    // Create the original file with content that should remain untouched
+    Files.writeString(expectedFile, originalContent);
+    
+    final int status =
+        new CommandLine(new GetCommand())
+            .execute(
+                "-o",
+                expectedFile.toString(),
+                "--use-temp-file",
+                mock.buildMockedUrl("/errorFile.txt").toString()
+            );
+
+    // Should fail with non-zero status
+    assertThat(status).isNotEqualTo(0);
+    // Original file should still exist with unchanged content
+    assertThat(expectedFile).exists();
+    assertThat(expectedFile).hasContent(originalContent);
+    // Any temporary download file should be cleaned up
+    assertThat(tempDir.resolve("out.txt.download")).doesNotExist();
+  }
+  
+  @Test
+  void preservesOriginalWhenDownloadHasInvalidContent(@TempDir Path tempDir) throws MalformedURLException, IOException {
+    // Set up a request that will result in an error during processing
+    // We'll return content with a valid Content-Length but corrupted/truncated data
+    mock.expectRequest("GET", "/interruptedFile.txt",
+        response()
+            .withHeader("Content-Length", "1000")  // Much larger than actual content
+            .withBody("This is only part of the expected content...")  // Truncated content
+    );
+
+    final Path expectedFile = tempDir.resolve("out.txt");
+    final String originalContent = "Original content that should remain intact";
+    
+    // Create the original file with content that should remain untouched
+    Files.writeString(expectedFile, originalContent);
+    
+    final int status =
+        new CommandLine(new GetCommand())
+            .execute(
+                "-o",
+                expectedFile.toString(),
+                "--use-temp-file",
+                mock.buildMockedUrl("/interruptedFile.txt").toString()
+            );
+    
+    // Original file should still exist with unchanged content
+    assertThat(expectedFile).exists();
+    assertThat(expectedFile).hasContent(originalContent);
+    
+    // Any temporary download file should be cleaned up
+    assertThat(tempDir.resolve("out.txt.download")).doesNotExist();
+  }
 
 }


### PR DESCRIPTION
I have a very slow internet connection, so interrupted downloads have often caused me problems. I saw that #434 from @potomato addressed this but seems to have stalled out. I'm a decent programmer but have no experience with java, so full disclosure that I used claude code to help me with this. I'm confident in the logic in GetCommand.java, but I'm not familiar with the testing framework. The tests look sensible to me and pass.