### PR TITLE
Fix CurseForge error handling and add ZIP-based mod processing

### DIFF
--- a/src/test/java/me/itzg/helpers/curseforge/CurseForgeApiClientTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/CurseForgeApiClientTest.java
@@ -1,15 +1,28 @@
 package me.itzg.helpers.curseforge;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.util.Collections;
-import me.itzg.helpers.cache.ApiCachingDisabled;
-import me.itzg.helpers.http.SharedFetch.Options;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import me.itzg.helpers.cache.ApiCachingDisabled;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidApiKeyException;
+import me.itzg.helpers.errors.RateLimitException;
+import me.itzg.helpers.http.FailedRequestException;
+import me.itzg.helpers.http.SharedFetch.Options;
 
 @WireMockTest
 class CurseForgeApiClientTest {
@@ -37,5 +50,153 @@ class CurseForgeApiClientTest {
         verify(getRequestedFor(urlEqualTo("/v1/categories?gameId=test&classesOnly=true"))
             .withHeader("x-api-key", equalTo("key"))
         );
+    }
+
+    @Test
+    void errorMapForbiddenInvalidApiKeyJson(WireMockRuntimeInfo wmInfo) {
+        @Language("JSON") final String body = "{\"error\": \"Invalid API key\"}";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+                .withHeader("Content-Type", "application/json")
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "invalid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(InvalidApiKeyException.class)
+                .hasMessageContaining("Access to http://localhost:")
+                .hasMessageContaining("is forbidden due to invalid API key.")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenRateLimitJson(WireMockRuntimeInfo wmInfo) {
+        @Language("JSON") final String body = "{\"error\": \"Too much traffic\"}";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+                .withHeader("Content-Type", "application/json")
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(RateLimitException.class)
+                .hasMessageContaining("Access to http://localhost:")
+                .hasMessageContaining("has been rate-limited: Too much traffic")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenGenericJson(WireMockRuntimeInfo wmInfo) {
+        @Language("JSON") final String body = "{\"error\": \"Some other error\"}";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+                .withHeader("Content-Type", "application/json")
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(GenericException.class)
+                .hasMessageContaining("CurseForge API forbidden response: Some other error")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenFetchingObjectContentFallback(WireMockRuntimeInfo wmInfo) {
+        final String body = "Fetching object content";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(GenericException.class)
+                .hasMessageContaining("CurseForge API returned forbidden for file metadata. This may indicate a temporary issue or unavailable file content.")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenTrafficStringFallback(WireMockRuntimeInfo wmInfo) {
+        final String body = "There might be too much traffic";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(RateLimitException.class)
+                .hasMessageContaining("Access to http://localhost:")
+                .hasMessageContaining("has been rate-limited.")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenGenericFallback(WireMockRuntimeInfo wmInfo) {
+        final String body = "Some unknown forbidden message";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(GenericException.class)
+                .hasMessageContaining("Access to http://localhost:")
+                .hasMessageContaining("forbidden with message: Some unknown forbidden message")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
+    }
+
+    @Test
+    void errorMapForbiddenJsonParseFailureFallback(WireMockRuntimeInfo wmInfo) {
+        final String body = "Invalid JSON body";
+        stubFor(get("/v1/mods/123/files/456")
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withBody(body)
+            )
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(), "valid", Options.builder().build(),
+            "test", new ApiCachingDisabled()
+        )) {
+            assertThatThrownBy(() -> client.getModFileInfo(123, 456).block())
+                .isInstanceOf(GenericException.class)
+                .hasMessageContaining("Access to http://localhost:")
+                .hasMessageContaining("forbidden with message: Invalid JSON body")
+                .hasCauseInstanceOf(FailedRequestException.class);
+        }
     }
 }

--- a/src/test/java/me/itzg/helpers/curseforge/CurseForgeInstallerTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/CurseForgeInstallerTest.java
@@ -3,7 +3,10 @@ package me.itzg.helpers.curseforge;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -52,6 +55,29 @@ GET https://api.curse.tools/v1/cf/mods/306770/files/4031402
      */
 
     @Test
+    void testModpackZipCreation() throws IOException {
+        // Test basic ZIP file creation and structure
+        Path modpackZip = createTestModpackZip();
+        
+        // Verify ZIP was created successfully
+        assertThat(modpackZip).exists();
+        assertThat(Files.size(modpackZip)).isGreaterThan(0);
+        
+        // This validates the ZIP structure we'll use for ZIP-based processing
+        // The actual installer tests would require proper API key setup
+    }
+
+    @Test
+    void testZipManifestExtraction() throws IOException {
+        // Test that we can create a valid modpack ZIP structure
+        Path modpackZip = createTestModpackZip();
+        
+        // Verify the ZIP contains expected structure for ZIP-based processing
+        assertThat(modpackZip).exists();
+        assertThat(Files.size(modpackZip)).isGreaterThan(100); // Should contain manifest + mod file
+    }
+
+    @Test
     @EnabledIfSystemProperty(named = "testEnableManualTests", matches = "true", disabledReason = "For manual recording")
     void testManual() throws IOException {
         final Path resultsFile = tempDir.resolve(".results.env");
@@ -61,5 +87,49 @@ GET https://api.curse.tools/v1/cf/mods/306770/files/4031402
 
         assertThat(tempDir)
             .isNotEmptyDirectory();
+    }
+
+    // Helper methods for creating test data
+
+    private Path createTestModpackZip() throws IOException {
+        Path zipPath = tempDir.resolve("test-modpack.zip");
+        
+        try (ZipArchiveOutputStream zos = new ZipArchiveOutputStream(Files.newOutputStream(zipPath))) {
+            // Add manifest.json
+            ZipArchiveEntry manifestEntry = new ZipArchiveEntry("manifest.json");
+            zos.putArchiveEntry(manifestEntry);
+            String manifestJson = "{\n" +
+                "  \"manifestType\": \"minecraftModpack\",\n" +
+                "  \"manifestVersion\": 1,\n" +
+                "  \"name\": \"Test Modpack\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"minecraft\": {\n" +
+                "    \"version\": \"1.19.2\",\n" +
+                "    \"modLoaders\": [\n" +
+                "      {\n" +
+                "        \"id\": \"forge-43.2.0\",\n" +
+                "        \"primary\": true\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"files\": [\n" +
+                "    {\n" +
+                "      \"projectID\": 123,\n" +
+                "      \"fileID\": 456,\n" +
+                "      \"required\": true\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+            zos.write(manifestJson.getBytes());
+            zos.closeArchiveEntry();
+            
+            // Add mods/test-mod.jar - this simulates the ZIP-based processing optimization
+            ZipArchiveEntry modEntry = new ZipArchiveEntry("mods/test-mod.jar");
+            zos.putArchiveEntry(modEntry);
+            zos.write("test mod content for ZIP-based extraction".getBytes());
+            zos.closeArchiveEntry();
+        }
+        
+        return zipPath;
     }
 }


### PR DESCRIPTION
Issue #484: Improve error classification for 403 responses and connection errors
- Parse JSON responses in errorMapForbidden to distinguish API key errors, rate limits, and other forbidden responses
- Add PrematureCloseException to retry filter for better connection error handling
- Fix misleading error messages for 'Fetching object content' responses

Issue [#3251](https://github.com/itzg/docker-minecraft-server/issues/3251): Optimize modpack installation by extracting mods from ZIP
- Extract server mods directly from modpack ZIP files when available
- Verify hashes of extracted mods before using them
- Reduce API calls from O(n) to O(k) where k << n for large modpacks
- Fall back to standard API downloads when ZIP extraction fails

Any and all feedback appreciated