### PR TITLE
Remove use of jansi due to Java 24+ warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,6 @@ dependencies {
   implementation 'ch.qos.logback:logback-core'
   implementation 'ch.qos.logback:logback-classic'
   implementation "info.picocli:picocli:${picocliVersion}"
-  implementation 'org.fusesource.jansi:jansi:2.4.2'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
   implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,6 @@
 <configuration>
     <conversionRule conversionWord="customHighlight" converterClass="me.itzg.helpers.logger.CustomHighlight" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>ACCEPT</onMatch>
@@ -14,7 +13,6 @@
         </encoder>
     </appender>
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>true</withJansi>
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>
             <onMatch>DENY</onMatch>


### PR DESCRIPTION
```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/usr/share/mc-image-helper-1.50.1/lib/jansi-2.4.2.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

[init] 2025-10-19 22:56:01+02:00 Enabling whitelist functionality

```