### PR TITLE
build(deps): bump io.projectreactor.netty:reactor-netty-http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   implementation 'com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39'
   implementation 'com.jayway.jsonpath:json-path:2.10.0'
   implementation 'org.apache.httpcomponents.client5:httpclient5:5.5.1'
-  implementation 'io.projectreactor.netty:reactor-netty-http:1.2.11'
+  implementation 'io.projectreactor.netty:reactor-netty-http:1.3.0'
   implementation 'org.apache.maven:maven-artifact:3.9.11'
   implementation 'commons-codec:commons-codec:1.19.0'
   // for RFC5987 parsing of content-disposition filename*


### PR DESCRIPTION
Upgrade reactor-netty-http to 1.3.0. This new release brings Netty to 4.2 and should fix #655.

The project does appear to build without issues, though I haven't extensively tested much else. I also took a lot at potentially breaking changes in the new release notes and could not find anything immediately obvious to address. Dependabot would have probably made this upgrade this week, but I had noted the issue and was tracking a fix.

- [Reactor Netty v1.3.0 release notes](https://github.com/reactor/reactor-netty/releases/tag/v1.3.0)
- [Netty 4.2 Migration Guide](https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide)