### PR TITLE
Allow custom modloader versions for auto curseforge

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -143,13 +143,7 @@ public class CurseForgeInstaller {
     Duration fileDownloadRetryMinDelay = Duration.ofSeconds(5);
 
     @Getter @Setter
-    private String customFabricLoaderVersion;
-
-    @Getter @Setter
-    private String customForgeVersion;
-
-    @Getter @Setter
-    private String customNeoForgeVersion;
+    private String customModLoaderVersion;
 
     /**
      */
@@ -984,25 +978,9 @@ public class CurseForgeInstaller {
         String loaderVersion = parts.length == 2 ? parts[1] : parts[2];
 
         // Override with custom versions if provided
-        switch (provider) {
-            case "fabric":
-                if (customFabricLoaderVersion != null) {
-                    log.info("Overriding Fabric loader version from {} to {}", loaderVersion, customFabricLoaderVersion);
-                    loaderVersion = customFabricLoaderVersion;
-                }
-                break;
-            case "forge":
-                if (customForgeVersion != null) {
-                    log.info("Overriding Forge version from {} to {}", loaderVersion, customForgeVersion);
-                    loaderVersion = customForgeVersion;
-                }
-                break;
-            case "neoforge":
-                if (customNeoForgeVersion != null) {
-                    log.info("Overriding NeoForge version from {} to {}", loaderVersion, customNeoForgeVersion);
-                    loaderVersion = customNeoForgeVersion;
-                }
-                break;
+        if (customModLoaderVersion != null) {
+            log.info("Overriding mod loader version from {} to {}", loaderVersion, customModLoaderVersion);
+            loaderVersion = customModLoaderVersion;
         }
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("install-curseforge", sharedFetchOptions)) {

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -142,6 +142,15 @@ public class CurseForgeInstaller {
     @Getter @Setter
     Duration fileDownloadRetryMinDelay = Duration.ofSeconds(5);
 
+    @Getter @Setter
+    private String customFabricLoaderVersion;
+
+    @Getter @Setter
+    private String customForgeVersion;
+
+    @Getter @Setter
+    private String customNeoForgeVersion;
+
     /**
      */
     public void installFromModpackZip(Path modpackZip, String slug) {
@@ -972,7 +981,29 @@ public class CurseForgeInstaller {
         }
 
         final String provider = parts[0];
-        final String loaderVersion = parts.length == 2 ? parts[1] : parts[2];
+        String loaderVersion = parts.length == 2 ? parts[1] : parts[2];
+
+        // Override with custom versions if provided
+        switch (provider) {
+            case "fabric":
+                if (customFabricLoaderVersion != null) {
+                    log.info("Overriding Fabric loader version from {} to {}", loaderVersion, customFabricLoaderVersion);
+                    loaderVersion = customFabricLoaderVersion;
+                }
+                break;
+            case "forge":
+                if (customForgeVersion != null) {
+                    log.info("Overriding Forge version from {} to {}", loaderVersion, customForgeVersion);
+                    loaderVersion = customForgeVersion;
+                }
+                break;
+            case "neoforge":
+                if (customNeoForgeVersion != null) {
+                    log.info("Overriding NeoForge version from {} to {}", loaderVersion, customNeoForgeVersion);
+                    loaderVersion = customNeoForgeVersion;
+                }
+                break;
+        }
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("install-curseforge", sharedFetchOptions)) {
 

--- a/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
@@ -89,20 +89,10 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
     )
     String apiKey;
 
-    @Option(names = "--fabric-loader-version", paramLabel = "VERSION",
-        description = "Override the Fabric Loader version specified in the modpack"
+    @Option(names = "--mod-loader-version", paramLabel = "VERSION",
+        description = "Override the mod loader version specified in the modpack"
     )
-    String fabricLoaderVersion;
-
-    @Option(names = "--forge-version", paramLabel = "VERSION",
-        description = "Override the Forge version specified in the modpack"
-    )
-    String forgeVersion;
-
-    @Option(names = "--neoforge-version", paramLabel = "VERSION",
-        description = "Override the NeoForge version specified in the modpack"
-    )
-    String neoforgeVersion;
+    String modLoaderVersion;
 
     @ArgGroup(exclusive = false)
     ExcludeIncludeArgs excludeIncludeArgs = new ExcludeIncludeArgs();
@@ -249,9 +239,7 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
             .setMaxConcurrentDownloads(maxConcurrentDownloads)
             .setFileDownloadRetries(fileDownloadRetries)
             .setFileDownloadRetryMinDelay(fileDownloadRetryMinDelay)
-            .setCustomFabricLoaderVersion(fabricLoaderVersion)
-            .setCustomForgeVersion(forgeVersion)
-            .setCustomNeoForgeVersion(neoforgeVersion);
+            .setCustomModLoaderVersion(modLoaderVersion);
 
         if (apiBaseUrl != null) {
             installer.setApiBaseUrl(apiBaseUrl);

--- a/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
@@ -89,6 +89,21 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
     )
     String apiKey;
 
+    @Option(names = "--fabric-loader-version", paramLabel = "VERSION",
+        description = "Override the Fabric Loader version specified in the modpack"
+    )
+    String fabricLoaderVersion;
+
+    @Option(names = "--forge-version", paramLabel = "VERSION",
+        description = "Override the Forge version specified in the modpack"
+    )
+    String forgeVersion;
+
+    @Option(names = "--neoforge-version", paramLabel = "VERSION",
+        description = "Override the NeoForge version specified in the modpack"
+    )
+    String neoforgeVersion;
+
     @ArgGroup(exclusive = false)
     ExcludeIncludeArgs excludeIncludeArgs = new ExcludeIncludeArgs();
 
@@ -233,7 +248,10 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
             .setForgeUrlArgs(forgeUrlArgs)
             .setMaxConcurrentDownloads(maxConcurrentDownloads)
             .setFileDownloadRetries(fileDownloadRetries)
-            .setFileDownloadRetryMinDelay(fileDownloadRetryMinDelay);
+            .setFileDownloadRetryMinDelay(fileDownloadRetryMinDelay)
+            .setCustomFabricLoaderVersion(fabricLoaderVersion)
+            .setCustomForgeVersion(forgeVersion)
+            .setCustomNeoForgeVersion(neoforgeVersion);
 
         if (apiBaseUrl != null) {
             installer.setApiBaseUrl(apiBaseUrl);


### PR DESCRIPTION
Adds `--fabric-loader-version`, `--forge-version`, and `--neoforge-version` options to override modpack-declared modloader versions for `install-curseforge` command.

Partial fix for https://github.com/itzg/docker-minecraft-server/issues/2653
Relates to https://github.com/itzg/docker-minecraft-server/pull/3759