### PR TITLE
Exclude Netty http3 to ensure Alpine musl support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,13 @@ dependencies {
   implementation 'com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39'
   implementation 'com.jayway.jsonpath:json-path:2.10.0'
   implementation 'org.apache.httpcomponents.client5:httpclient5:5.5.1'
-  implementation 'io.projectreactor.netty:reactor-netty-http:1.3.0'
+  implementation ('io.projectreactor.netty:reactor-netty-http:1.3.0') {
+    // http3/quic is not functional on Alpine due to absence of glibc/ld-linux
+    // Error loading shared library ld-linux-x86-64.so.2:
+    //    No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
+    exclude group: 'io.netty', module: 'netty-codec-http3'
+  }
+  implementation 'io.netty.incubator:netty-incubator-codec-native-quic:0.0.74.Final'
   implementation 'org.apache.maven:maven-artifact:3.9.11'
   implementation 'commons-codec:commons-codec:1.20.0'
   // for RFC5987 parsing of content-disposition filename*


### PR DESCRIPTION
Addresses the following failure when running subcommand like `resolve-minecraft-version` on alpine (such as itzg/minecraft-server:java21-alpine)

```
[init] Resolving type given PAPER
Exception in thread "main" java.lang.UnsatisfiedLinkError: failed to load the required native library
	at io.netty.handler.codec.quic.Quic.ensureAvailability(Quic.java:87)
	at io.netty.handler.codec.quic.QuicheQuicSslContext.<init>(QuicheQuicSslContext.java:160)
	at io.netty.handler.codec.quic.QuicSslContextBuilder.build(QuicSslContextBuilder.java:404)
	at reactor.netty.http.Http3SslContextSpec.sslContext(Http3SslContextSpec.java:105)
	at reactor.netty.tcp.SslProvider.<init>(SslProvider.java:343)
	at reactor.netty.tcp.SslProvider$Build.build(SslProvider.java:650)
	at reactor.netty.http.client.HttpClientSecure.<clinit>(HttpClientSecure.java:82)
	at reactor.netty.http.client.HttpClient.secure(HttpClient.java:1498)
	at me.itzg.helpers.http.SharedFetch.applyUseHttp2(SharedFetch.java:108)
	at me.itzg.helpers.http.SharedFetch.<init>(SharedFetch.java:64)
	at me.itzg.helpers.http.Fetch.sharedFetch(Fetch.java:21)
	at me.itzg.helpers.paper.PaperDownloadsClient.<init>(PaperDownloadsClient.java:34)
	at me.itzg.helpers.paper.InstallPaperCommand.call(InstallPaperCommand.java:113)
	at me.itzg.helpers.paper.InstallPaperCommand.call(InstallPaperCommand.java:38)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2031)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at me.itzg.helpers.McImageHelper.main(McImageHelper.java:176)
Caused by: java.lang.UnsatisfiedLinkError: /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(Unknown Source)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
	at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
	at java.base/java.lang.Runtime.load0(Unknown Source)
	at java.base/java.lang.System.load(Unknown Source)
	at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:36)
	at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:395)
	at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:218)
	at io.netty.handler.codec.quic.Quiche.loadNativeLibrary(Quiche.java:80)
	at io.netty.handler.codec.quic.Quiche.<clinit>(Quiche.java:59)
	at io.netty.handler.codec.quic.Quic.<clinit>(Quic.java:46)
	at io.netty.handler.codec.quic.QuicheQuicSslContext.<clinit>(QuicheQuicSslContext.java:81)
	at io.netty.handler.codec.quic.QuicSslContextBuilder.build(QuicSslContextBuilder.java:402)
	... 20 more
	Suppressed: java.lang.UnsatisfiedLinkError: /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
		at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
		at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(Unknown Source)
		at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
		at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(Unknown Source)
		at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
		at java.base/java.lang.Runtime.load0(Unknown Source)
		at java.base/java.lang.System.load(Unknown Source)
		at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:36)
		at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
		at java.base/java.lang.reflect.Method.invoke(Unknown Source)
		at io.netty.util.internal.NativeLibraryLoader$1.run(NativeLibraryLoader.java:421)
		at java.base/java.security.AccessController.doPrivileged(Unknown Source)
		at io.netty.util.internal.NativeLibraryLoader.loadLibraryByHelper(NativeLibraryLoader.java:413)
		at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:387)
		... 26 more
	Suppressed: java.lang.UnsatisfiedLinkError: no netty_quiche42_linux_x86_64 in java.library.path: /opt/java/openjdk/lib/server:/opt/java/openjdk/lib:/opt/java/openjdk/../lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
		at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
		at java.base/java.lang.Runtime.loadLibrary0(Unknown Source)
		at java.base/java.lang.System.loadLibrary(Unknown Source)
		at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
		at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:395)
		at io.netty.util.internal.NativeLibraryLoader.load(NativeLibraryLoader.java:166)
		... 25 more
		Suppressed: java.lang.UnsatisfiedLinkError: no netty_quiche42_linux_x86_64 in java.library.path: /opt/java/openjdk/lib/server:/opt/java/openjdk/lib:/opt/java/openjdk/../lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
			at java.base/java.lang.ClassLoader.loadLibrary(Unknown Source)
			at java.base/java.lang.Runtime.loadLibrary0(Unknown Source)
			at java.base/java.lang.System.loadLibrary(Unknown Source)
			at io.netty.util.internal.NativeLibraryUtil.loadLibrary(NativeLibraryUtil.java:38)
			at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
			at java.base/java.lang.reflect.Method.invoke(Unknown Source)
			at io.netty.util.internal.NativeLibraryLoader$1.run(NativeLibraryLoader.java:421)
			at java.base/java.security.AccessController.doPrivileged(Unknown Source)
			at io.netty.util.internal.NativeLibraryLoader.loadLibraryByHelper(NativeLibraryLoader.java:413)
			at io.netty.util.internal.NativeLibraryLoader.loadLibrary(NativeLibraryLoader.java:387)
			... 26 more
```