### PR TITLE
Add enable-native-access to starter script JVM args

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -11,6 +11,7 @@ jobs:
   publish:
     uses: itzg/github-workflows/.github/workflows/gradle-build.yml@main
     with:
+      java-version: '25'
       arguments: >
         test 
         githubPublishApplication

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     uses: itzg/github-workflows/.github/workflows/gradle-build.yml@main
     with:
+      java-version: '25'
       arguments: test
       include-test-report: true
       retest-showing-standard-streams: true

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,8 @@ jar {
 
 java {
   // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 8
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  toolchain.languageVersion = JavaLanguageVersion.of(21)
+  sourceCompatibility = JavaVersion.VERSION_11
+  toolchain.languageVersion = JavaLanguageVersion.of(25)
 }
 
 test {
@@ -60,6 +60,10 @@ test {
 
 application {
   mainClass = 'me.itzg.helpers.McImageHelper'
+
+  // Enable native access due to
+  // WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/geoff/.gradle/caches/modules-2/files-2.1/io.netty/netty-common/4.2.7.Final/11aa30df26af4fca3239ac1917f303a280f301e1/netty-common-4.2.7.Final.jar)
+  applicationDefaultJvmArgs = ['--enable-native-access=ALL-UNNAMED']
 }
 
 project.tasks.distTar {
@@ -96,11 +100,11 @@ dependencies {
   implementation 'com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39'
   implementation 'com.jayway.jsonpath:json-path:2.10.0'
   implementation 'org.apache.httpcomponents.client5:httpclient5:5.5.1'
-  implementation ('io.projectreactor.netty:reactor-netty-http:1.3.0') {
+  implementation ('io.projectreactor.netty:reactor-netty-http:1.3.1') {
     // http3/quic is not functional on Alpine due to absence of glibc/ld-linux
     // Error loading shared library ld-linux-x86-64.so.2:
     //    No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
-    exclude group: 'io.netty', module: 'netty-codec-http3'
+    exclude group: 'io.netty', module: 'netty-codec-native-quic'
   }
   implementation 'io.netty.incubator:netty-incubator-codec-native-quic:0.0.74.Final'
   implementation 'org.apache.maven:maven-artifact:3.9.11'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum


### PR DESCRIPTION
**IMPORTANT** Java 8 is no longer supported for executing the application starter scripts

Addresses

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/geoff/.gradle/caches/modules-2/files-2.1/io.netty/netty-common/4.2.7.Final/11aa30df26af4fca3239ac1917f303a280f301e1/netty-common-4.2.7.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

First step of #659