### PR TITLE
Add enable-native-access to starter script JVM args

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ jar {
 
 java {
   // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 8
-  sourceCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_11
   toolchain.languageVersion = JavaLanguageVersion.of(21)
 }
 
@@ -60,6 +60,10 @@ test {
 
 application {
   mainClass = 'me.itzg.helpers.McImageHelper'
+
+  // Enable native access due to
+  // WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/geoff/.gradle/caches/modules-2/files-2.1/io.netty/netty-common/4.2.7.Final/11aa30df26af4fca3239ac1917f303a280f301e1/netty-common-4.2.7.Final.jar)
+  applicationDefaultJvmArgs = ['--enable-native-access=ALL-UNNAMED']
 }
 
 project.tasks.distTar {


### PR DESCRIPTION
**IMPORTANT** Java 8 is no longer supported for executing the application starter scripts

Addresses

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/geoff/.gradle/caches/modules-2/files-2.1/io.netty/netty-common/4.2.7.Final/11aa30df26af4fca3239ac1917f303a280f301e1/netty-common-4.2.7.Final.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

First step of #659