### PR TITLE
Revert "Add enable-native-access to starter script JVM args"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ jar {
 
 java {
   // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 8
-  sourceCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_1_8
   toolchain.languageVersion = JavaLanguageVersion.of(21)
 }
 
@@ -60,10 +60,6 @@ test {
 
 application {
   mainClass = 'me.itzg.helpers.McImageHelper'
-
-  // Enable native access due to
-  // WARNING: java.lang.System::loadLibrary has been called by io.netty.util.internal.NativeLibraryUtil in an unnamed module (file:/Users/geoff/.gradle/caches/modules-2/files-2.1/io.netty/netty-common/4.2.7.Final/11aa30df26af4fca3239ac1917f303a280f301e1/netty-common-4.2.7.Final.jar)
-  applicationDefaultJvmArgs = ['--enable-native-access=ALL-UNNAMED']
 }
 
 project.tasks.distTar {


### PR DESCRIPTION
Reverts itzg/mc-image-helper#680

It turns out this is only supporting starting with Java 17:

> The command-line option --enable-native-access=ALL-UNNAMED was introduced in Java 17. It is supported in subsequent Java versions as part of an ongoing effort to prepare for restricting the default use of the Java Native Interface (JNI) and the Foreign Function and Memory (FFM) API.

Should use env var $MC_IMAGE_HELPER_OPTS for adjusting this for mc-image-helper based on java version.