### PR TITLE
cf: resolve remaining exclude/include slugs after first UnknownModException

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -715,14 +715,14 @@ public class CurseForgeInstaller {
                     return Mono.just(id);
                 } catch (NumberFormatException e) {
                     return context.cfApi.searchMod(s, modsClassId)
-                        .map(CurseForgeMod::getId);
+                        .map(CurseForgeMod::getId)
+                        .doOnError(UnknownModException.class, ex -> {
+                            log.warn("Unable to resolve {} for exclude/include", ex.getSlug(), ex);
+                        })
+                        .onErrorComplete(UnknownModException.class);
                 }
             })
             .checkpoint()
-            .doOnError(UnknownModException.class, e -> {
-                log.warn("Unable to resolve {} for exclude/include", e.getSlug(), e);
-            })
-            .onErrorComplete(UnknownModException.class)
             .collect(Collectors.toSet());
     }
 

--- a/src/test/java/me/itzg/helpers/curseforge/CurseForgeApiClientTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/CurseForgeApiClientTest.java
@@ -6,10 +6,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 import me.itzg.helpers.cache.ApiCachingDisabled;
+import me.itzg.helpers.curseforge.model.CurseForgeMod;
 import me.itzg.helpers.http.SharedFetch.Options;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
 
 @WireMockTest
 class CurseForgeApiClientTest {
@@ -37,5 +41,31 @@ class CurseForgeApiClientTest {
         verify(getRequestedFor(urlEqualTo("/v1/categories?gameId=test&classesOnly=true"))
             .withHeader("x-api-key", equalTo("key"))
         );
+    }
+
+    @Test
+    void unknownModDoesNotPreventResolvingOthers(WireMockRuntimeInfo wmInfo) {
+        stubFor(get(urlPathEqualTo("/v1/mods/search"))
+            .withQueryParam("slug", equalTo("unknown-mod"))
+            .willReturn(jsonResponse("{\"data\": []}", 200))
+        );
+        stubFor(get(urlPathEqualTo("/v1/mods/search"))
+            .withQueryParam("slug", equalTo("known-mod"))
+            .willReturn(jsonResponse("{\"data\": [{\"id\": 100, \"classId\": 6, \"gameId\": 432}]}", 200))
+        );
+
+        try (CurseForgeApiClient client = new CurseForgeApiClient(wmInfo.getHttpBaseUrl(),
+            "key", Options.builder().build(), "432", new ApiCachingDisabled()
+        )) {
+            final Set<Integer> ids = Flux.just("unknown-mod", "known-mod")
+                .flatMap(slug -> client.searchMod(slug, 6)
+                    .map(CurseForgeMod::getId)
+                    .onErrorComplete(UnknownModException.class)
+                )
+                .collect(Collectors.toSet())
+                .block();
+
+            assertThat(ids).containsExactly(100);
+        }
     }
 }


### PR DESCRIPTION
Outer flux was completing on the first `UnknownModException` - subsequent slugs were not resolving as a result. Stream closed.

Included unit test. Would've liked the test the method directly, but its private and deeply nested. Happy to update if needed. Resolves #699