### PR TITLE
Apache cxf removal relating to rfc5987

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,9 +109,6 @@ dependencies {
   }
   implementation 'org.apache.maven:maven-artifact:3.9.12'
   implementation 'commons-codec:commons-codec:1.21.0'
-  // for RFC5987 parsing of content-disposition filename*
-  // 3.5.x is last of Java8 compatible: https://cxf.apache.org/download.html
-  implementation 'org.apache.cxf:cxf-core:[3.5.6,3.6.0)'
   implementation 'org.jetbrains:annotations:26.0.2-1'
 
   // https://commons.apache.org/proper/commons-compress/zip.html

--- a/src/test/java/me/itzg/helpers/http/FilenameExtractorTest.java
+++ b/src/test/java/me/itzg/helpers/http/FilenameExtractorTest.java
@@ -1,0 +1,14 @@
+package me.itzg.helpers.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class FilenameExtractorTest {
+
+  @Test
+  void decodeRfc5987PercentEncodedUtf8() {
+    assertThat(FilenameExtractor.decodeRfc5987("Hello%20Overworld%21", "UTF-8"))
+        .isEqualTo("Hello Overworld!");
+  }
+}


### PR DESCRIPTION
Replaced cxf decoder w/ parity impl, allowing removal of cxf dep. Added unit test.

Fixes https://github.com/itzg/docker-minecraft-server/issues/3731