### PR TITLE
Offline username being hashed twice

### DIFF
--- a/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
+++ b/src/main/java/me/itzg/helpers/users/ManageUsersCommand.java
@@ -370,13 +370,7 @@ public class ManageUsersCommand implements Callable<Integer> {
     }
 
     private static String getOfflineUUID(String username) {
-        final MessageDigest digester;
-        try {
-            digester = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            throw new GenericException("Failed to create MD5 digester to generate offline player UUID", e);
-        }
-        final byte[] bytes = digester.digest(("OfflinePlayer:"+username).getBytes(StandardCharsets.UTF_8));
+        final byte[] bytes = ("OfflinePlayer:"+username).getBytes(StandardCharsets.UTF_8);
 
         return UUID.nameUUIDFromBytes(bytes).toString();
     }

--- a/src/test/java/me/itzg/helpers/users/ManageUsersCommandTest.java
+++ b/src/test/java/me/itzg/helpers/users/ManageUsersCommandTest.java
@@ -25,10 +25,10 @@ class ManageUsersCommandTest {
 
     private static final String USER1_ID = "3f5f20286a85445fa7b46100e70c2b3a";
     private static final String USER1_UUID = "3f5f2028-6a85-445f-a7b4-6100e70c2b3a";
-    private static final String USER1_OFFLINE_UUID = "95825a72-847d-3e1f-983a-e144b90ec1c9";
+    private static final String USER1_OFFLINE_UUID = "fb4cdad9-642b-358f-8f6f-717981c9f42b";
     private static final String USER2_ID = "5e5a1b2294b14f5892466062597e4c91";
     private static final String USER2_UUID = "5e5a1b22-94b1-4f58-9246-6062597e4c91";
-    private static final String USER2_OFFLINE_UUID = "357f8b0a-3577-32e9-aafd-6602bb4b6cbf";
+    private static final String USER2_OFFLINE_UUID = "6e7d9aa0-0da2-390c-ab6a-377df9d77518";
 
     @TempDir
     Path tempDir;


### PR DESCRIPTION
There's a mistake that got introduced in https://github.com/itzg/mc-image-helper/pull/638

The username would get hashed first before being passed to `UUID.nameUUIDFromBytes` where it would get hashed again by the function, causing it to generate the wrong UUID

Ref: [UUID.java#L168-L181](https://github.com/openjdk/jdk/blob/jdk-25%2B36/src/java.base/share/classes/java/util/UUID.java#L168-L181)

