### PR TITLE
Feat: Clean server Jar libraries on server install

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,8 @@ Installs selected PaperMC
       --channel=<channel>    This is ignored for now
       --check-updates        Check for updates and exit with status code 0 when
                                available
+      --clean-libraries      Remove currently installed and not required
+                               libraries
       --connection-pool-max-idle-timeout=DURATION
 
       --connection-pool-pending-acquire-timeout=DURATION
@@ -1530,4 +1532,3 @@ One of the following identifiers or can be prefixed with `list of ` to indicate 
   }
 }
 ```
-

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -82,7 +82,7 @@ public class LibraryCleaner {
             try {
                 Files.delete(libraryFolder.resolve(s));
             } catch (Exception e) {
-                log.warn("Failed to delete library {} {}", s, e);
+                log.warn("Failed to delete library {}", s, e);
             }
 
         }
@@ -189,12 +189,12 @@ public class LibraryCleaner {
                                 Files.delete(dir);
                             }
                         } catch (IOException e) {
-                            log.error("Failed to delete directory {} {}", dir.toString(), e);
+                            log.error("Failed to delete directory {}", dir, e);
                         }
                     });
 
         } catch (Exception e) {
-            log.error("Failed to walk directory {} {}", root.toString(), e);
+            log.error("Failed to walk directory {}", root, e);
         }
     }
 }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -57,13 +57,16 @@ public class LibraryCleaner {
         }
 
         final List<String> installedLibraries;
+
+
+        if (!Files.isDirectory(libraryFolder)) {
+            log.debug("Failed to read library folder {}", libraryFolder);
+        }
+
         try {
             installedLibraries = readInstalledLibraries(libraryFolder);
-        } catch (Exception e) {
-
-            // Will fail on fresh install as no libs installed
-            // Therefore no /library created
-            log.debug("Failed to read installed libraries {}", e);
+        } catch (IOException e) {
+            log.warn("Failed to read installed libraries", e);
             return;
         }
 

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -99,16 +99,14 @@ public class LibraryCleaner {
      * @throws IOException
      */
     private List<String> readJarLibraries(Path jarFile, LibraryListPaths libraryListPath) throws IOException {
-        List<String> libs = new ArrayList<String>();
+        final List<String> libs;
 
         try (JarFile serverJar = new JarFile(jarFile.toString());) {
 
             JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
 
             if (libraryList == null) {
-                log.error("Failed to read library list {} for server type {}", libraryListPath.getPath(),
-                        libraryListPath.name());
-                return libs;
+                throw new IOException("Failed to read library list for server jar");
             }
 
             try (
@@ -137,9 +135,7 @@ public class LibraryCleaner {
 
             }
 
-        } catch (Exception e) {
-            log.error("Failed to read server jar {} {}", jarFile.toString(), e);
-        }
+        } 
 
         return libs;
     }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -165,9 +165,10 @@ public class LibraryCleaner {
      */
     private HashSet<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
         HashSet<String> installedNotRequired = new HashSet<String>(installed);
+        HashSet<String> requiredSet = new HashSet<String>(required);
 
         for (String s : installed) {
-            if (required.contains(s)) {
+            if (requiredSet.contains(s)) {
                 installedNotRequired.remove(s);
             }
         }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -64,7 +65,7 @@ public class LibraryCleaner {
             return;
         }
 
-        oldLibraries = compareInstalledRequiredLibraries(installedLibraries, requiredLibraries);
+        oldLibraries = new ArrayList<String>(compareInstalledRequiredLibraries(installedLibraries, requiredLibraries));
 
         if (oldLibraries.isEmpty()) {
             return;
@@ -162,8 +163,8 @@ public class LibraryCleaner {
      * @param required  List of libraries required by Server Jar
      * @return List of currently installed libraries not required by the Server Jar
      */
-    private List<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
-        List<String> installedNotRequired = new ArrayList<String>(installed);
+    private HashSet<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
+        HashSet<String> installedNotRequired = new HashSet<String>(installed);
 
         for (String s : installed) {
             if (required.contains(s)) {

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -1,0 +1,178 @@
+package me.itzg.helpers.libraries;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * LibraryCleaner
+ */
+@Slf4j
+@AllArgsConstructor
+public class LibraryCleaner {
+    private static String INSTALLED_LIBRARY_FOLDER = "libraries";
+
+    // @TODO I believe all server jar types save libs to "/libraries" however will
+    // have to verify when implementing for further types
+
+    private final LibraryListPaths libraryListPath;
+    private final Path serverJar;
+    private final Path workingFolder;
+    private final Path libraryFolder;
+
+    public LibraryCleaner(Path serverJar, LibraryListPaths libraryListPath) {
+        this.serverJar = serverJar;
+        this.libraryListPath = libraryListPath;
+
+        this.workingFolder = serverJar.getParent();
+        this.libraryFolder = workingFolder.resolve(INSTALLED_LIBRARY_FOLDER);
+    }
+
+    /**
+     * cleanLibraries reads currently installed libraries against required libraries
+     * for Server Jar, removes non-required libraries
+     */
+    public void cleanLibraries() {
+        List<String> requiredLibraries, installedLibraries, oldLibraries;
+
+        try {
+            requiredLibraries = readJarLibraries(serverJar, libraryListPath);
+        } catch (Exception e) {
+            log.debug("Failed to read server jar libraries", e);
+            return;
+        }
+
+        try {
+            installedLibraries = readInstalledLibraries(libraryFolder);
+        } catch (Exception e) {
+
+            // Will fail on fresh install as no libs installed
+            // Therefore no /library created
+            log.debug("Failed to read installed libraries {}", e);
+            return;
+        }
+
+        oldLibraries = compareInstalledRequiredLibraries(installedLibraries, requiredLibraries);
+
+        if (oldLibraries.isEmpty()) {
+            return;
+        }
+
+        log.info("Removing " + String.valueOf(oldLibraries.size()) + " deprecated installed libraries");
+
+        for (String s : oldLibraries) {
+            try {
+                Files.delete(libraryFolder.resolve(s));
+                deleteEmptyParentDirectories(libraryFolder, libraryFolder.resolve(s));
+            } catch (Exception e) {
+                log.debug("Failed to delete library {} {}", s, e);
+            }
+
+        }
+    }
+
+    /**
+     * Reads required libraries from inside Jarfile Manifest
+     * 
+     * @param jarFile         Path to server Jar
+     * @param libraryListPath Path to library list inside jar
+     * @return List of all libraries required by server jar
+     * @throws IOException
+     */
+    private List<String> readJarLibraries(Path jarFile, LibraryListPaths libraryListPath) throws IOException {
+        List<String> libs = new ArrayList<String>();
+
+        JarFile serverJar = new JarFile(jarFile.toString());
+        JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPATH());
+
+        InputStream is = serverJar.getInputStream(libraryList);
+        InputStreamReader isr = new InputStreamReader(is);
+        BufferedReader br = new BufferedReader(isr);
+
+        libs = br.lines()
+                .map(String::trim)
+                .map(s -> s.split("\\s+"))
+                .filter(parts -> parts.length > 1)
+                .map(parts -> parts[2])
+                .collect(Collectors.toList());
+
+        serverJar.close();
+        return libs;
+    }
+
+    /**
+     * @param libraryFolder Folder where libraries are currently installed
+     * @return returns list of all individual library Jars currently installed
+     * @throws IOException
+     */
+    private List<String> readInstalledLibraries(Path libraryFolder) throws IOException {
+        List<String> libs = new ArrayList<String>();
+
+        libs = Files.walk(libraryFolder)
+                .filter(Files::isRegularFile)
+                .map(libraryFolder::relativize)
+                .map(Path::toString)
+                .collect(Collectors.toList());
+
+        return libs;
+    }
+
+    /**
+     * Takes the differance of currently installed and required libraries
+     * 
+     * @param installed List of currently installed libraries
+     * @param required  List of libraries required by Server Jar
+     * @return List of currently installed libraries not required by the Server Jar
+     */
+    private List<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
+        List<String> installedNotRequired = new ArrayList<String>(installed);
+
+        for (String s : installed) {
+            if (required.contains(s)) {
+                installedNotRequired.remove(s);
+            }
+        }
+
+        return installedNotRequired;
+    }
+
+    /**
+     * Takes currently delete file, moves upwards in filesystem and deletes any
+     * empty folders
+     * 
+     * @param baseRoot    Root folder where libraries are installed
+     * @param deletedFile Path to recently deleted file
+     */
+    private void deleteEmptyParentDirectories(Path baseRoot, Path deletedFile) {
+        Path current = deletedFile.getParent();
+        while (current != null && !current.equals(baseRoot)) {
+            try (Stream<Path> entries = Files.list(current)) {
+                if (entries.findAny().isPresent()) {
+                    return;
+                }
+            } catch (IOException e) {
+                log.debug("Failed to inspect directory {}", current, e);
+                return;
+            }
+            try {
+                Files.delete(current);
+            } catch (IOException e) {
+                log.debug("Failed to delete empty directory {}", current, e);
+                return;
+            }
+            current = current.getParent();
+        }
+    }
+}

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -109,6 +109,18 @@ public class LibraryCleaner {
                     InputStreamReader isr = new InputStreamReader(is);
                     BufferedReader br = new BufferedReader(isr);) {
 
+                // Libraries List file contains rows of entries, split into three columns
+                // <sha256> <groupId:artifactId:version> <path>, for example
+                // 5d803eb7348a27468c6172daef2f0d77260dd63cde377ebfa73e36789ae8fcee com.mojang:logging:1.6.11 com/mojang/logging/1.6.11/logging-1.6.11.jar
+                // 7e9941bbdcca244d878ea95bfff788fd9ba6a65af757f24be6c632930d61c7ed com.mysql:mysql-connector-j:9.2.0 com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
+                //
+                // When the libraries get expanded, they simply extract the jars referenced in
+                // the path column to ./libraries/{path}
+                //
+                // Reader iterates through each line, trimming whitespace, then selecting the
+                // third column, fetching the path of
+                // the jar
+
                 libs = br.lines()
                         .map(String::trim)
                         .map(s -> s.split("\\s+"))

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -77,7 +77,7 @@ public class LibraryCleaner {
                 Files.delete(libraryFolder.resolve(s));
                 deleteEmptyParentDirectories(libraryFolder, libraryFolder.resolve(s));
             } catch (Exception e) {
-                log.debug("Failed to delete library {} {}", s, e);
+                log.warn("Failed to delete library {} {}", s, e);
             }
 
         }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -47,8 +47,8 @@ public class LibraryCleaner {
      * for Server Jar, removes non-required libraries
      */
     public void cleanLibraries() {
-        List<String> requiredLibraries, installedLibraries, oldLibraries;
 
+        final List<String> requiredLibraries;
         try {
             requiredLibraries = readJarLibraries(serverJar, libraryListPath);
         } catch (Exception e) {
@@ -56,6 +56,7 @@ public class LibraryCleaner {
             return;
         }
 
+        final List<String> installedLibraries;
         try {
             installedLibraries = readInstalledLibraries(libraryFolder);
         } catch (Exception e) {
@@ -66,7 +67,7 @@ public class LibraryCleaner {
             return;
         }
 
-        oldLibraries = new ArrayList<String>(compareInstalledRequiredLibraries(installedLibraries, requiredLibraries));
+        final List<String> oldLibraries = compareInstalledRequiredLibraries(installedLibraries, requiredLibraries);
 
         if (oldLibraries.isEmpty()) {
             return;

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -95,7 +95,7 @@ public class LibraryCleaner {
         List<String> libs = new ArrayList<String>();
 
         JarFile serverJar = new JarFile(jarFile.toString());
-        JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPATH());
+        JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
 
         InputStream is = serverJar.getInputStream(libraryList);
         InputStreamReader isr = new InputStreamReader(is);

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -1,6 +1,7 @@
 package me.itzg.helpers.libraries;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -94,8 +95,22 @@ public class LibraryCleaner {
     private List<String> readJarLibraries(Path jarFile, LibraryListPaths libraryListPath) throws IOException {
         List<String> libs = new ArrayList<String>();
 
-        JarFile serverJar = new JarFile(jarFile.toString());
+        JarFile serverJar;
+
+        try {
+            serverJar = new JarFile(jarFile.toString());
+        } catch (Exception e) {
+            log.error("Failed to read server jar {} {}", jarFile.toString(), e);
+            return libs;
+        }
+
         JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
+
+        if (libraryList == null) {
+            log.error("Failed to read library List {} for server type {}", libraryListPath.getPath(), libraryListPath.name());
+            serverJar.close();
+            return libs;
+        }
 
         InputStream is = serverJar.getInputStream(libraryList);
         InputStreamReader isr = new InputStreamReader(is);

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -1,7 +1,6 @@
 package me.itzg.helpers.libraries;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -95,39 +94,34 @@ public class LibraryCleaner {
     private List<String> readJarLibraries(Path jarFile, LibraryListPaths libraryListPath) throws IOException {
         List<String> libs = new ArrayList<String>();
 
-        JarFile serverJar;
+        try (JarFile serverJar = new JarFile(jarFile.toString());) {
 
-        try {
-            serverJar = new JarFile(jarFile.toString());
+            JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
+
+            if (libraryList == null) {
+                log.error("Failed to read library list {} for server type {}", libraryListPath.getPath(),
+                        libraryListPath.name());
+                return libs;
+            }
+
+            try (
+                    InputStream is = serverJar.getInputStream(libraryList);
+                    InputStreamReader isr = new InputStreamReader(is);
+                    BufferedReader br = new BufferedReader(isr);) {
+
+                libs = br.lines()
+                        .map(String::trim)
+                        .map(s -> s.split("\\s+"))
+                        .filter(parts -> parts.length > 1)
+                        .map(parts -> parts[2])
+                        .collect(Collectors.toList());
+
+            }
+
         } catch (Exception e) {
             log.error("Failed to read server jar {} {}", jarFile.toString(), e);
-            return libs;
         }
 
-        JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
-
-        if (libraryList == null) {
-            log.error("Failed to read library List {} for server type {}", libraryListPath.getPath(),
-                    libraryListPath.name());
-            serverJar.close();
-            return libs;
-        }
-
-        try (
-                InputStream is = serverJar.getInputStream(libraryList);
-                InputStreamReader isr = new InputStreamReader(is);
-                BufferedReader br = new BufferedReader(isr);) {
-
-            libs = br.lines()
-                    .map(String::trim)
-                    .map(s -> s.split("\\s+"))
-                    .filter(parts -> parts.length > 1)
-                    .map(parts -> parts[2])
-                    .collect(Collectors.toList());
-
-        }
-
-        serverJar.close();
         return libs;
     }
 

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -70,7 +70,7 @@ public class LibraryCleaner {
             return;
         }
 
-        log.info("Removing " + String.valueOf(oldLibraries.size()) + " deprecated installed libraries");
+        log.info("Removing {} deprecated installed libraries", String.valueOf(oldLibraries.size()));
 
         for (String s : oldLibraries) {
             try {

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -165,17 +165,12 @@ public class LibraryCleaner {
      * @param required  List of libraries required by Server Jar
      * @return List of currently installed libraries not required by the Server Jar
      */
-    private HashSet<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
+    private List<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
         HashSet<String> installedNotRequired = new HashSet<String>(installed);
-        HashSet<String> requiredSet = new HashSet<String>(required);
 
-        for (String s : installed) {
-            if (requiredSet.contains(s)) {
-                installedNotRequired.remove(s);
-            }
-        }
+        installedNotRequired.removeAll(required);
 
-        return installedNotRequired;
+        return installedNotRequired.stream().collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -52,7 +52,7 @@ public class LibraryCleaner {
         try {
             requiredLibraries = readJarLibraries(serverJar, libraryListPath);
         } catch (Exception e) {
-            log.debug("Failed to read server jar libraries", e);
+            log.warn("Failed to read server jar libraries", e);
             return;
         }
 

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -107,21 +107,25 @@ public class LibraryCleaner {
         JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
 
         if (libraryList == null) {
-            log.error("Failed to read library List {} for server type {}", libraryListPath.getPath(), libraryListPath.name());
+            log.error("Failed to read library List {} for server type {}", libraryListPath.getPath(),
+                    libraryListPath.name());
             serverJar.close();
             return libs;
         }
 
-        InputStream is = serverJar.getInputStream(libraryList);
-        InputStreamReader isr = new InputStreamReader(is);
-        BufferedReader br = new BufferedReader(isr);
+        try (
+                InputStream is = serverJar.getInputStream(libraryList);
+                InputStreamReader isr = new InputStreamReader(is);
+                BufferedReader br = new BufferedReader(isr);) {
 
-        libs = br.lines()
-                .map(String::trim)
-                .map(s -> s.split("\\s+"))
-                .filter(parts -> parts.length > 1)
-                .map(parts -> parts[2])
-                .collect(Collectors.toList());
+            libs = br.lines()
+                    .map(String::trim)
+                    .map(s -> s.split("\\s+"))
+                    .filter(parts -> parts.length > 1)
+                    .map(parts -> parts[2])
+                    .collect(Collectors.toList());
+
+        }
 
         serverJar.close();
         return libs;

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.jar.JarEntry;
@@ -76,12 +77,13 @@ public class LibraryCleaner {
         for (String s : oldLibraries) {
             try {
                 Files.delete(libraryFolder.resolve(s));
-                deleteEmptyParentDirectories(libraryFolder, libraryFolder.resolve(s));
             } catch (Exception e) {
                 log.warn("Failed to delete library {} {}", s, e);
             }
 
         }
+
+        deleteEmptyDirectories(libraryFolder);
     }
 
     /**
@@ -177,30 +179,27 @@ public class LibraryCleaner {
     }
 
     /**
-     * Takes currently delete file, moves upwards in filesystem and deletes any
-     * empty folders
-     * 
-     * @param baseRoot    Root folder where libraries are installed
-     * @param deletedFile Path to recently deleted file
+     * Reads all files inside directory, deletes empty subdirectories
+     *
+     * @param root Root directory to search inside
      */
-    private void deleteEmptyParentDirectories(Path baseRoot, Path deletedFile) {
-        Path current = deletedFile.getParent();
-        while (current != null && !current.equals(baseRoot)) {
-            try (Stream<Path> entries = Files.list(current)) {
-                if (entries.findAny().isPresent()) {
-                    return;
-                }
-            } catch (IOException e) {
-                log.debug("Failed to inspect directory {}", current, e);
-                return;
-            }
-            try {
-                Files.delete(current);
-            } catch (IOException e) {
-                log.debug("Failed to delete empty directory {}", current, e);
-                return;
-            }
-            current = current.getParent();
+    private void deleteEmptyDirectories(Path root) {
+        try (Stream<Path> stream = Files.walk(root)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .filter(Files::isDirectory)
+                    .forEach(dir -> {
+
+                        try (Stream<Path> files = Files.list(dir)) {
+                            if (files.findAny().isEmpty()) {
+                                Files.delete(dir);
+                            }
+                        } catch (IOException e) {
+                            log.error("Failed to delete directory {} {}", dir.toString(), e);
+                        }
+                    });
+
+        } catch (Exception e) {
+            log.error("Failed to walk directory {} {}", root.toString(), e);
         }
     }
 }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -147,6 +147,7 @@ public class LibraryCleaner {
 
         libs = Files.walk(libraryFolder)
                 .filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().toString().endsWith(".jar"))
                 .map(libraryFolder::relativize)
                 .map(Path::toString)
                 .collect(Collectors.toList());

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -150,7 +150,7 @@ public class LibraryCleaner {
 
         libs = Files.walk(libraryFolder)
                 .filter(Files::isRegularFile)
-                .filter(path -> path.getFileName().toString().endsWith(".jar"))
+                .filter(path -> path.getFileName().endsWith(".jar"))
                 .map(libraryFolder::relativize)
                 .map(Path::toString)
                 .collect(Collectors.toList());

--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -9,5 +9,5 @@ public enum LibraryListPaths {
     PAPER("META-INF/libraries.list"),
     FORGE("bootstrap-shim.list");
 
-    private String PATH;
+    private String path;
 }

--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -1,0 +1,13 @@
+package me.itzg.helpers.libraries;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum LibraryListPaths {
+    PAPER("META-INF/libraries.list"),
+    FORGE("bootstrap-shim.list");
+
+    private String PATH;
+}

--- a/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
+++ b/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
@@ -22,6 +22,8 @@ import me.itzg.helpers.http.FileDownloadStatusHandler;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import me.itzg.helpers.paper.PaperDownloadsClient.VersionBuildFile;
 import me.itzg.helpers.paper.model.VersionMeta;
 import me.itzg.helpers.sync.MultiCopyManifest;
@@ -94,6 +96,9 @@ public class InstallPaperCommand implements Callable<Integer> {
     @Option(names = "--results-file", description = ResultsFileWriter.OPTION_DESCRIPTION, paramLabel = "FILE")
     Path resultsFile;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove currently installed and not required libraries")
+    Boolean cleanLibraries;
+
     @ArgGroup
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
@@ -144,6 +149,10 @@ public class InstallPaperCommand implements Callable<Integer> {
                 results.writeType(inputs.coordinates.project != null ?
                     inputs.coordinates.project.toUpperCase() : "PAPER");
             }
+        }
+
+        if (cleanLibraries) {
+            new LibraryCleaner(result.serverJar, LibraryListPaths.PAPER).cleanLibraries();
         }
 
         Manifests.cleanup(outputDirectory, oldManifest, result.newManifest, log);


### PR DESCRIPTION
When server jars are ran, they install a set of dependencies to "./libraries". When updating server versions, they may install or update libraries, however they do not remove old libraries.

Implemented a `--clean-libraries` flag which defaults to false. This option checks the required libs from the current server jar against the installed libs in `./libraries` and deletes all installed and not required libraries.

Currently this only supports Paper jars, however support will be added for further TYPES.

Partial implementation to fix itzg/docker-minecraft-server#3821