### PR TITLE
fix(libraryCleanUp): Fix bug in filter always returning false

### DIFF
--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -150,7 +150,7 @@ public class LibraryCleaner {
 
         libs = Files.walk(libraryFolder)
                 .filter(Files::isRegularFile)
-                .filter(path -> path.toString().endsWith(".jar"))
+                .filter(path -> path.getFileName().toString().endsWith(".jar"))
                 .map(libraryFolder::relativize)
                 .map(Path::toString)
                 .collect(Collectors.toList());

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -150,7 +150,7 @@ public class LibraryCleaner {
 
         libs = Files.walk(libraryFolder)
                 .filter(Files::isRegularFile)
-                .filter(path -> path.getFileName().endsWith(".jar"))
+                .filter(path -> path.toString().endsWith(".jar"))
                 .map(libraryFolder::relativize)
                 .map(Path::toString)
                 .collect(Collectors.toList());


### PR DESCRIPTION
The filter was intended to filter only ".jar" files, however, the `Path.getFileName()` function returns a `Path`, therefore we were performing a `.endsWith()` on a `Path` object, not a `String`. 

A `Path.endsWith(String other)`;
"Tests if this path ends with a Path, constructed by converting the given path string, in exactly the manner specified by the [endsWith(Path)](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Path.html#endsWith-java.nio.file.Path-) method. On UNIX for example, the path "foo/bar" ends with "foo/bar" and "bar". It does not end with "r" or "/bar"."

Because "foo.jar" doesn't end with ".jar" according to `Path.endsWith(String other)`, it will always return `false`.

In the context of the function `List<String> readInstalledLibraries(Path libraryFolder)`, it will always return a empty `List<String>`