### PR TITLE
Feat: Clean server Jar libraries on Quilt install

### DIFF
--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public enum LibraryListPaths {
     PAPER("META-INF/libraries.list"),
+    QUILT("META-INF/libraries.list"),
     FORGE("bootstrap-shim.list");
 
     private String path;

--- a/src/main/java/me/itzg/helpers/quilt/InstallQuiltCommand.java
+++ b/src/main/java/me/itzg/helpers/quilt/InstallQuiltCommand.java
@@ -57,6 +57,10 @@ public class InstallQuiltCommand implements Callable<Integer> {
     @Option(names = "--force-reinstall", defaultValue = "${env:QUILT_FORCE_REINSTALL:-false}")
     boolean forceReinstall;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove currently installed and not required libraries")
+    Boolean cleanLibraries;
+
+
     @Override
     public Integer call() throws Exception {
 
@@ -66,6 +70,7 @@ public class InstallQuiltCommand implements Callable<Integer> {
         )
             .setResultsFile(resultsFile)
             .setForceReinstall(forceReinstall)
+            .setCleanLibraries(cleanLibraries)
         ) {
             if (inputs.installerUrl != null) {
                 installer.installFromUrl(inputs.installerUrl, loaderVersion);

--- a/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
+++ b/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
@@ -18,6 +18,8 @@ import me.itzg.helpers.files.Manifests;
 import me.itzg.helpers.files.ResultsFileWriter;
 import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import me.itzg.helpers.mvn.MavenRepoApi;
 import me.itzg.helpers.versions.MinecraftVersionsApi;
 import org.jetbrains.annotations.Blocking;
@@ -43,6 +45,9 @@ public class QuiltInstaller implements AutoCloseable {
 
     @Setter
     private boolean forceReinstall;
+
+    @Setter 
+    boolean cleanLibraries;
 
     public QuiltInstaller(String repoUrl, SharedFetch.Options fetchOptions, Path outputDir, String minecraftVersion) {
 
@@ -192,6 +197,14 @@ public class QuiltInstaller implements AutoCloseable {
             Files.move(installedLauncher, resolvedLauncher, StandardCopyOption.REPLACE_EXISTING);
         } catch (IOException e) {
             throw new GenericException("Failed to rename server launcher", e);
+        }
+
+
+        if (cleanLibraries) {
+            final Path serverJar = outputDir.resolve("server.jar");
+            if (Files.exists(serverJar)) {
+                new LibraryCleaner(serverJar, LibraryListPaths.QUILT).cleanLibraries();
+            }
         }
 
         if (resultsFile != null) {

--- a/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
+++ b/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
@@ -205,7 +205,7 @@ public class QuiltInstaller implements AutoCloseable {
             if (Files.exists(serverJar)) {
                 new LibraryCleaner(serverJar, LibraryListPaths.QUILT).cleanLibraries();
             } else {
-                log.debug("Failed to read jar at {}", serverJar);
+                log.warn("Failed to read jar at {}", serverJar);
             }
         }
 

--- a/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
+++ b/src/main/java/me/itzg/helpers/quilt/QuiltInstaller.java
@@ -204,6 +204,8 @@ public class QuiltInstaller implements AutoCloseable {
             final Path serverJar = outputDir.resolve("server.jar");
             if (Files.exists(serverJar)) {
                 new LibraryCleaner(serverJar, LibraryListPaths.QUILT).cleanLibraries();
+            } else {
+                log.debug("Failed to read jar at {}", serverJar);
             }
         }
 


### PR DESCRIPTION
From what i understand of the quilt installer, it downloads a slim entry jar, which is formatted as `quilt-server-{mc-version}-{quilt-loader-version}.jar`. The launcher then starts `server.jar` to start the server.

From my testing, the naming of the main jar; `server.jar` is consistent across quilt versions, both inside mc-image-helper and outside when installing manually

The `server.jar` contains the LibrariesList, which is why its directly passed to the LibraryCleaner, instead of the `...launcher.jar`
