### PR TITLE
Clean server Jar libraries on Purpur install

### DIFF
--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public enum LibraryListPaths {
     PAPER("META-INF/libraries.list"),
+    PURPUR("META-INF/libraries.list"),
     FORGE("bootstrap-shim.list");
 
     private String path;

--- a/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
+++ b/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
@@ -21,6 +21,8 @@ import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import me.itzg.helpers.purpur.model.VersionMeta;
 import me.itzg.helpers.sync.MultiCopyManifest;
 import picocli.CommandLine;
@@ -117,6 +119,9 @@ public class InstallPurpurCommand implements Callable<Integer> {
             }
         }
 
+        if (cleanLibraries) {
+            new LibraryCleaner(result.serverJar, LibraryListPaths.PURPUR).cleanLibraries();
+        }
         Manifests.cleanup(outputDirectory, oldManifest, result.newManifest, log);
         Manifests.save(outputDirectory, PurpurManifest.ID, result.newManifest);
 

--- a/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
+++ b/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
@@ -80,6 +80,8 @@ public class InstallPurpurCommand implements Callable<Integer> {
     @Option(names = "--results-file", description = ResultsFileWriter.OPTION_DESCRIPTION, paramLabel = "FILE")
     Path resultsFile;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove currently installed and not required libraries")
+    Boolean cleanLibraries;
     @ArgGroup
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 


### PR DESCRIPTION
Add picocli flag "--clean-libraries" and cleanLibraries logic similar to that implemented in `PaperInstallCommand` in #748 