### PR TITLE
ServerLibraryCleaner: Add early return on failure to read Libraries folder

### DIFF
--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -61,6 +61,7 @@ public class LibraryCleaner {
 
         if (!Files.isDirectory(libraryFolder)) {
             log.debug("Failed to read library folder {}", libraryFolder);
+            return;
         }
 
         try {


### PR DESCRIPTION
Mentioned in itzg/docker-minecraft-server#4046

When a server is *initially* created, and the `--clean-libraries` flag is passed, the `./libraries` folder in the output dir doesn't exist yet.

There was already a check on this, `Files.isDirectory` returns "false if the file does not exist, is not a directory, or it cannot be determined if the file is a directory or not".

```java
if (!Files.isDirectory(libraryFolder)) {
  log.debug("Failed to read library folder {}", libraryFolder);
}

```

However there was no early return statement if it returned false, and instead was propagated to the user as a Warn and exception logged

```java
try {
  installedLibraries = readInstalledLibraries(libraryFolder);
} catch (IOException e) {
  log.warn("Failed to read installed libraries", e);
  return;
}
```

Added a return statement on `Files.isDirectory` returning false