### PR TITLE
cf: clarify exception when extractModpackManifest encounters a directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jar {
 java {
   // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 11
   toolchain {
-    languageVersion = JavaLanguageVersion.of(11)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 // https://docs.gradle.org/current/userguide/toolchains.html#sec:release-flag-toolchain

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -7,11 +7,9 @@ import static me.itzg.helpers.curseforge.CurseForgeApiClient.CACHING_NAMESPACE;
 import static me.itzg.helpers.curseforge.CurseForgeApiClient.modFileDownloadStatusHandler;
 import static me.itzg.helpers.singles.MoreCollections.safeStreamFrom;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import io.netty.channel.ChannelException;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -50,11 +48,12 @@ import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidApiKeyException;
 import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.fabric.FabricLauncherInstaller;
+import me.itzg.helpers.files.IoStreams;
 import me.itzg.helpers.files.Manifests;
 import me.itzg.helpers.files.ReactiveFileUtils;
 import me.itzg.helpers.files.ResultsFileWriter;
-import me.itzg.helpers.forge.ForgeLikeInstaller;
 import me.itzg.helpers.forge.ForgeInstallerResolver;
+import me.itzg.helpers.forge.ForgeLikeInstaller;
 import me.itzg.helpers.forge.ForgeUrlArgs;
 import me.itzg.helpers.forge.NeoForgeInstallerResolver;
 import me.itzg.helpers.http.FailedRequestException;
@@ -62,8 +61,6 @@ import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.Uris;
 import me.itzg.helpers.json.ObjectMappers;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -1053,18 +1050,8 @@ public class CurseForgeInstaller {
     }
 
     private MinecraftModpackManifest extractModpackManifest(Path modpackZip) throws IOException {
-        try (ZipFile zipFile = ZipFile.builder().setPath(modpackZip).get()) {
-            final ZipArchiveEntry entry = zipFile.getEntry("manifest.json");
-            if (entry != null) {
-                try (InputStream in = zipFile.getInputStream(entry)) {
-                    return ObjectMappers.defaultMapper().readValue(in, MinecraftModpackManifest.class);
-                } catch (JsonMappingException e) {
-                    throw new InvalidParameterException("The modpack's manifest file was not valid -- did you make sure to reference a client, not server, file?", e);
-                }
-            }
-        }
-        throw new InvalidParameterException(
-            "Modpack file is missing a manifest. Make sure to reference a client modpack file."
+        return IoStreams.readFileFromZip(modpackZip, "manifest.json",
+            in -> ObjectMappers.defaultMapper().readValue(in, MinecraftModpackManifest.class)
         );
     }
 

--- a/src/main/java/me/itzg/helpers/files/IoStreams.java
+++ b/src/main/java/me/itzg/helpers/files/IoStreams.java
@@ -2,7 +2,9 @@ package me.itzg.helpers.files;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import me.itzg.helpers.errors.InvalidParameterException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jetbrains.annotations.Nullable;
@@ -22,6 +24,12 @@ public class IoStreams {
      */
     @Nullable
     public static <T> T readFileFromZip(Path zipFile, String entryName, EntryReader<T> entryReader) throws IOException {
+        if (!Files.exists(zipFile)) {
+            throw new InvalidParameterException("Zip file does not exist: " + zipFile);
+        }
+        if (Files.isDirectory(zipFile)) {
+            throw new InvalidParameterException("Zip file seems to be a directory: " + zipFile);
+        }
         try (ZipFile zip = ZipFile.builder().setPath(zipFile).get()) {
             final ZipArchiveEntry entry = zip.getEntry(entryName);
             if (entry != null) {


### PR DESCRIPTION
[From Discord](https://discord.com/channels/660567679458869252/660567682751528981/1502705223389544489)

```
mc-1  | Caused by: java.io.IOException: Is a directory
mc-1  |         at java.base/sun.nio.ch.UnixFileDispatcherImpl.read0(Native Method)
mc-1  |         at java.base/sun.nio.ch.UnixFileDispatcherImpl.read(Unknown Source)
mc-1  |         at java.base/sun.nio.ch.IOUtil.readIntoNativeBuffer(Unknown Source)
mc-1  |         at java.base/sun.nio.ch.IOUtil.read(Unknown Source)
mc-1  |         at java.base/sun.nio.ch.IOUtil.read(Unknown Source)
mc-1  |         at java.base/sun.nio.ch.FileChannelImpl.implRead(Unknown Source)
mc-1  |         at java.base/sun.nio.ch.FileChannelImpl.read(Unknown Source)
mc-1  |         at org.apache.commons.io.IOUtils.read(IOUtils.java:1949)
mc-1  |         at org.apache.commons.compress.utils.IOUtils.readFully(IOUtils.java:214)
mc-1  |         at org.apache.commons.compress.archivers.zip.ZipFile.tryToLocateSignature(ZipFile.java:654)
mc-1  |         at org.apache.commons.compress.archivers.zip.ZipFile.positionAtEndOfCentralDirectoryRecord(ZipFile.java:582)
mc-1  |         at org.apache.commons.compress.archivers.zip.ZipFile.openZipChannel(ZipFile.java:527)
mc-1  |         at org.apache.commons.compress.archivers.zip.ZipFile.access$000(ZipFile.java:94)
mc-1  |         at org.apache.commons.compress.archivers.zip.ZipFile$Builder.get(ZipFile.java:167)
mc-1  |         at me.itzg.helpers.curseforge.CurseForgeInstaller.extractModpackManifest(CurseForgeInstaller.java:1056)
mc-1  |         at me.itzg.helpers.curseforge.CurseForgeInstaller.lambda$installFromModpackZip$0(CurseForgeInstaller.java:158)
mc-1  |         at me.itzg.helpers.curseforge.CurseForgeInstaller.install(CurseForgeInstaller.java:249)
mc-1  |         ... 12 common frames omitted
mc-1  | [init] [ERROR] Failed to auto-install CurseForge modpack 
```