### PR TITLE
Bring ServerLibraryCleaner into java8 brach

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,8 @@ Installs selected PaperMC
       --channel=<channel>
       --check-updates        Check for updates and exit with status code 0 when
                                available
+      --clean-libraries      Remove currently installed and not required
+                               libraries
       --connection-pool-max-idle-timeout=DURATION
 
       --connection-pool-pending-acquire-timeout=DURATION
@@ -1358,4 +1360,3 @@ One of the following identifiers or can be prefixed with `list of ` to indicate 
   }
 }
 ```
-

--- a/build.gradle
+++ b/build.gradle
@@ -100,9 +100,11 @@ dependencies {
     // http3/quic is not functional on Alpine due to absence of glibc/ld-linux
     // Error loading shared library ld-linux-x86-64.so.2:
     //    No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
-    exclude group: 'io.netty', module: 'netty-codec-http3'
+    // Also needs to handle
+    // java.lang.NoClassDefFoundError: io/netty/handler/codec/quic/Quic
+    //	at reactor.netty.http.internal.Http3.isHttp3Available(Http3.java:35)
+    exclude group: 'io.netty', module: 'netty-codec-native-quic'
   }
-  implementation 'io.netty.incubator:netty-incubator-codec-native-quic:0.0.75.Final'
   implementation 'org.apache.maven:maven-artifact:3.9.12'
   implementation 'commons-codec:commons-codec:1.21.0'
   // for RFC5987 parsing of content-disposition filename*

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -150,7 +150,7 @@ public class LibraryCleaner {
 
         libs = Files.walk(libraryFolder)
                 .filter(Files::isRegularFile)
-                .filter(path -> path.getFileName().endsWith(".jar"))
+                .filter(path -> path.getFileName().toString().endsWith(".jar"))
                 .map(libraryFolder::relativize)
                 .map(Path::toString)
                 .collect(Collectors.toList());

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -1,0 +1,200 @@
+package me.itzg.helpers.libraries;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * LibraryCleaner
+ */
+@Slf4j
+@AllArgsConstructor
+public class LibraryCleaner {
+    private static String INSTALLED_LIBRARY_FOLDER = "libraries";
+
+    // @TODO I believe all server jar types save libs to "/libraries" however will
+    // have to verify when implementing for further types
+
+    private final LibraryListPaths libraryListPath;
+    private final Path serverJar;
+    private final Path workingFolder;
+    private final Path libraryFolder;
+
+    public LibraryCleaner(Path serverJar, LibraryListPaths libraryListPath) {
+        this.serverJar = serverJar;
+        this.libraryListPath = libraryListPath;
+
+        this.workingFolder = serverJar.getParent();
+        this.libraryFolder = workingFolder.resolve(INSTALLED_LIBRARY_FOLDER);
+    }
+
+    /**
+     * cleanLibraries reads currently installed libraries against required libraries
+     * for Server Jar, removes non-required libraries
+     */
+    public void cleanLibraries() {
+
+        final List<String> requiredLibraries;
+        try {
+            requiredLibraries = readJarLibraries(serverJar, libraryListPath);
+        } catch (Exception e) {
+            log.warn("Failed to read server jar libraries", e);
+            return;
+        }
+
+        final List<String> installedLibraries;
+
+
+        if (!Files.isDirectory(libraryFolder)) {
+            log.debug("Failed to read library folder {}", libraryFolder);
+        }
+
+        try {
+            installedLibraries = readInstalledLibraries(libraryFolder);
+        } catch (IOException e) {
+            log.warn("Failed to read installed libraries", e);
+            return;
+        }
+
+        final List<String> oldLibraries = compareInstalledRequiredLibraries(installedLibraries, requiredLibraries);
+
+        if (oldLibraries.isEmpty()) {
+            return;
+        }
+
+        log.info("Removing {} deprecated installed libraries", String.valueOf(oldLibraries.size()));
+
+        for (String s : oldLibraries) {
+            try {
+                Files.delete(libraryFolder.resolve(s));
+            } catch (Exception e) {
+                log.warn("Failed to delete library {}", s, e);
+            }
+
+        }
+
+        deleteEmptyDirectories(libraryFolder);
+    }
+
+    /**
+     * Reads required libraries from inside Jarfile Manifest
+     * 
+     * @param jarFile         Path to server Jar
+     * @param libraryListPath Path to library list inside jar
+     * @return List of all libraries required by server jar
+     * @throws IOException
+     */
+    private List<String> readJarLibraries(Path jarFile, LibraryListPaths libraryListPath) throws IOException {
+        final List<String> libs;
+
+        try (JarFile serverJar = new JarFile(jarFile.toString());) {
+
+            JarEntry libraryList = serverJar.getJarEntry(libraryListPath.getPath());
+
+            if (libraryList == null) {
+                throw new IOException("Failed to read library list for server jar");
+            }
+
+            try (
+                    InputStream is = serverJar.getInputStream(libraryList);
+                    InputStreamReader isr = new InputStreamReader(is);
+                    BufferedReader br = new BufferedReader(isr);) {
+
+                // Libraries List file contains rows of entries, split into three columns
+                // <sha256> <groupId:artifactId:version> <path>, for example
+                // 5d803eb7348a27468c6172daef2f0d77260dd63cde377ebfa73e36789ae8fcee com.mojang:logging:1.6.11 com/mojang/logging/1.6.11/logging-1.6.11.jar
+                // 7e9941bbdcca244d878ea95bfff788fd9ba6a65af757f24be6c632930d61c7ed com.mysql:mysql-connector-j:9.2.0 com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
+                //
+                // When the libraries get expanded, they simply extract the jars referenced in
+                // the path column to ./libraries/{path}
+                //
+                // Reader iterates through each line, trimming whitespace, then selecting the
+                // third column, fetching the path of
+                // the jar
+
+                libs = br.lines()
+                        .map(String::trim)
+                        .map(s -> s.split("\\s+"))
+                        .filter(parts -> parts.length > 1)
+                        .map(parts -> parts[2])
+                        .collect(Collectors.toList());
+
+            }
+
+        } 
+
+        return libs;
+    }
+
+    /**
+     * @param libraryFolder Folder where libraries are currently installed
+     * @return returns list of all individual library Jars currently installed
+     * @throws IOException
+     */
+    private List<String> readInstalledLibraries(Path libraryFolder) throws IOException {
+        List<String> libs = new ArrayList<String>();
+
+        libs = Files.walk(libraryFolder)
+                .filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().endsWith(".jar"))
+                .map(libraryFolder::relativize)
+                .map(Path::toString)
+                .collect(Collectors.toList());
+
+        return libs;
+    }
+
+    /**
+     * Takes the differance of currently installed and required libraries
+     * 
+     * @param installed List of currently installed libraries
+     * @param required  List of libraries required by Server Jar
+     * @return List of currently installed libraries not required by the Server Jar
+     */
+    private List<String> compareInstalledRequiredLibraries(List<String> installed, List<String> required) {
+        HashSet<String> installedNotRequired = new HashSet<String>(installed);
+
+        installedNotRequired.removeAll(required);
+
+        return installedNotRequired.stream().collect(Collectors.toList());
+    }
+
+    /**
+     * Reads all files inside directory, deletes empty subdirectories
+     *
+     * @param root Root directory to search inside
+     */
+    private void deleteEmptyDirectories(Path root) {
+        try (Stream<Path> stream = Files.walk(root)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .filter(Files::isDirectory)
+                    .forEach(dir -> {
+
+                        try (Stream<Path> files = Files.list(dir)) {
+                            if (files.findAny().isEmpty()) {
+                                Files.delete(dir);
+                            }
+                        } catch (IOException e) {
+                            log.error("Failed to delete directory {}", dir, e);
+                        }
+                    });
+
+        } catch (Exception e) {
+            log.error("Failed to walk directory {}", root, e);
+        }
+    }
+}

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -61,6 +61,7 @@ public class LibraryCleaner {
 
         if (!Files.isDirectory(libraryFolder)) {
             log.debug("Failed to read library folder {}", libraryFolder);
+            return;
         }
 
         try {

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -186,7 +186,7 @@ public class LibraryCleaner {
                     .forEach(dir -> {
 
                         try (Stream<Path> files = Files.list(dir)) {
-                            if (files.findAny().isEmpty()) {
+                            if (!files.findAny().isPresent()) {
                                 Files.delete(dir);
                             }
                         } catch (IOException e) {

--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -1,0 +1,13 @@
+package me.itzg.helpers.libraries;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum LibraryListPaths {
+    PAPER("META-INF/libraries.list"),
+    FORGE("bootstrap-shim.list");
+
+    private String path;
+}

--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public enum LibraryListPaths {
     PAPER("META-INF/libraries.list"),
+    PURPUR("META-INF/libraries.list"),
     FORGE("bootstrap-shim.list");
 
     private String path;

--- a/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
+++ b/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
@@ -22,6 +22,8 @@ import me.itzg.helpers.http.FileDownloadStatusHandler;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import me.itzg.helpers.paper.PaperDownloadsClient.VersionBuildFile;
 import me.itzg.helpers.paper.model.VersionMeta;
 import me.itzg.helpers.sync.MultiCopyManifest;
@@ -94,6 +96,9 @@ public class InstallPaperCommand implements Callable<Integer> {
     @Option(names = "--results-file", description = ResultsFileWriter.OPTION_DESCRIPTION, paramLabel = "FILE")
     Path resultsFile;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove currently installed and not required libraries")
+    Boolean cleanLibraries;
+
     @ArgGroup
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
@@ -144,6 +149,10 @@ public class InstallPaperCommand implements Callable<Integer> {
                 results.writeType(inputs.coordinates.project != null ?
                     inputs.coordinates.project.toUpperCase() : "PAPER");
             }
+        }
+
+        if (cleanLibraries) {
+            new LibraryCleaner(result.serverJar, LibraryListPaths.PAPER).cleanLibraries();
         }
 
         Manifests.cleanup(outputDirectory, oldManifest, result.newManifest, log);

--- a/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
+++ b/src/main/java/me/itzg/helpers/purpur/InstallPurpurCommand.java
@@ -21,6 +21,8 @@ import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import me.itzg.helpers.purpur.model.VersionMeta;
 import me.itzg.helpers.sync.MultiCopyManifest;
 import picocli.CommandLine;
@@ -80,6 +82,8 @@ public class InstallPurpurCommand implements Callable<Integer> {
     @Option(names = "--results-file", description = ResultsFileWriter.OPTION_DESCRIPTION, paramLabel = "FILE")
     Path resultsFile;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove currently installed and not required libraries")
+    Boolean cleanLibraries;
     @ArgGroup
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
@@ -115,6 +119,9 @@ public class InstallPurpurCommand implements Callable<Integer> {
             }
         }
 
+        if (cleanLibraries) {
+            new LibraryCleaner(result.serverJar, LibraryListPaths.PURPUR).cleanLibraries();
+        }
         Manifests.cleanup(outputDirectory, oldManifest, result.newManifest, log);
         Manifests.save(outputDirectory, PurpurManifest.ID, result.newManifest);
 


### PR DESCRIPTION
Discussed in itzg/docker-minecraft-server#4046

Bring ServerLibraryCleaner into slower moving Java8 branch

Also brings in Netty fix in `build.gradle` from #682 which fixes error `Exception in thread "main" java.lang.NoClassDefFoundError: io/netty/handler/codec/quic/Quic`