### PR TITLE
build(deps): Fix Junit and Netty dependency errors in Java8 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,9 +100,11 @@ dependencies {
     // http3/quic is not functional on Alpine due to absence of glibc/ld-linux
     // Error loading shared library ld-linux-x86-64.so.2:
     //    No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
-    exclude group: 'io.netty', module: 'netty-codec-http3'
+    // Also needs to handle
+    // java.lang.NoClassDefFoundError: io/netty/handler/codec/quic/Quic
+    //	at reactor.netty.http.internal.Http3.isHttp3Available(Http3.java:35)
+    exclude group: 'io.netty', module: 'netty-codec-native-quic'
   }
-  implementation 'io.netty.incubator:netty-incubator-codec-native-quic:0.0.75.Final'
   implementation 'org.apache.maven:maven-artifact:3.9.12'
   implementation 'commons-codec:commons-codec:1.21.0'
   // for RFC5987 parsing of content-disposition filename*

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
   testImplementation(platform("org.junit:junit-bom:[5.11.4,5.12.0)"))
   testImplementation 'org.junit.jupiter:junit-jupiter'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
   testImplementation 'org.mockito:mockito-junit-jupiter:5.21.0'
   // would like to transition these to wiremock


### PR DESCRIPTION
Currently test fails with message; `The automatic loading of test framework implementation dependencies has been deprecated. Solution: Declare the desired test framework directly on the test suite or explicitly declare the test framework implementation dependencies on the test's runtime classpath`

Gradle has deprecated auto-loading of test launchers and now must manually be declared

["If using JUnit 5, an explicit runtimeOnly dependency on junit-platform-launcher is required in addition to the existing implementation dependency on the test engine."](https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#test_framework_implementation_dependencies)
