### PR TITLE
feat: add install-oci-pack command

### DIFF
--- a/src/main/java/me/itzg/helpers/McImageHelper.java
+++ b/src/main/java/me/itzg/helpers/McImageHelper.java
@@ -32,6 +32,7 @@ import me.itzg.helpers.modrinth.InstallModrinthModpackCommand;
 import me.itzg.helpers.modrinth.ModrinthCommand;
 import me.itzg.helpers.modrinth.VersionFromModrinthProjectsCommand;
 import me.itzg.helpers.mvn.MavenDownloadCommand;
+import me.itzg.helpers.oci.InstallOciPackCommand;
 import me.itzg.helpers.paper.InstallPaperCommand;
 import me.itzg.helpers.patch.PatchCommand;
 import me.itzg.helpers.properties.SetPropertiesCommand;
@@ -78,6 +79,7 @@ import picocli.CommandLine.Spec;
         InstallForgeCommand.class,
         InstallModrinthModpackCommand.class,
         InstallNeoForgeCommand.class,
+        InstallOciPackCommand.class,
         InstallPaperCommand.class,
         InstallPurpurCommand.class,
         InstallQuiltCommand.class,

--- a/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
+++ b/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
@@ -1,0 +1,139 @@
+package me.itzg.helpers.oci;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.oci.OciManifest.OciLayer;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Option;
+
+@Command(name = "install-oci-pack",
+    description = "Pulls an OCI artifact and writes its layer blobs to disk in apply order",
+    mixinStandardHelpOptions = true)
+@Slf4j
+public class InstallOciPackCommand implements Callable<Integer> {
+
+    @Option(names = "--ref", required = true, paramLabel = "REF",
+        description = "OCI reference, e.g. ghcr.io/owner/pack:v1 or ghcr.io/owner/pack@sha256:..."
+            + "%nThe optional oci:// prefix is tolerated.")
+    String ref;
+
+    @Option(names = "--output-directory", required = true, paramLabel = "DIR",
+        description = "Directory where layer blobs are written. Acts as a content-addressed"
+            + " cache between invocations: layers whose digest already exists are not re-downloaded.")
+    Path outputDirectory;
+
+    @Option(names = "--auth-file", paramLabel = "FILE",
+        description = "Registry login JSON (root auths map). When unset, reads the default"
+            + " login file under the user home directory if present.")
+    Path authFile;
+
+    @Option(names = "--filename-strategy", defaultValue = "title",
+        description = "How to name layer files on disk. Valid values: ${COMPLETION-CANDIDATES}."
+            + "%nDefault: ${DEFAULT-VALUE}")
+    FilenameStrategy filenameStrategy;
+
+    @Option(names = "--layer-list-file", paramLabel = "FILE",
+        description = "Write each pulled layer's absolute path on its own line to this file,"
+            + " in manifest layer order. Suitable for `mapfile -t ... < FILE` in shell."
+            + " When omitted, layer paths are also printed to stdout for interactive use.")
+    Path layerListFile;
+
+    // Allows tests to capture stdout without intercepting the JVM's
+    @Setter
+    private PrintStream out = System.out;
+
+    // Visible for tests; production code always uses HTTPS
+    @Setter
+    String scheme = "https";
+
+    public enum FilenameStrategy {
+        title,
+        digest
+    }
+
+    @Override
+    public Integer call() throws IOException {
+        final OciReference parsedRef = OciReference.parse(ref);
+        Files.createDirectories(outputDirectory);
+
+        final RegistryAuthJson auths = RegistryAuthJson.load(authFile);
+        try (OciClient client = new OciClient(auths, scheme)) {
+            log.info("Resolving OCI artifact {}", parsedRef);
+            final OciManifest manifest = client.fetchManifest(parsedRef);
+            if (manifest.getLayers() == null || manifest.getLayers().isEmpty()) {
+                throw new GenericException(
+                    "OCI artifact " + parsedRef + " declares no layers");
+            }
+
+            final List<Path> written = new ArrayList<>(manifest.getLayers().size());
+            for (final OciLayer layer : manifest.getLayers()) {
+                final Path target = outputDirectory.resolve(safeFilename(layer));
+                client.downloadBlob(parsedRef, layer.getDigest(), target);
+                written.add(target);
+            }
+
+            if (layerListFile != null) {
+                Files.createDirectories(
+                    layerListFile.toAbsolutePath().getParent());
+                try (BufferedWriter w = Files.newBufferedWriter(
+                    layerListFile, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                    for (final Path p : written) {
+                        w.write(p.toAbsolutePath().toString());
+                        w.newLine();
+                    }
+                }
+            } else {
+                for (final Path p : written) {
+                    out.println(p.toAbsolutePath());
+                }
+            }
+        }
+
+        return ExitCode.OK;
+    }
+
+    private static final int MAX_FILENAME_LEN = 200;
+
+    private String safeFilename(OciLayer layer) {
+        final String candidate;
+        if (filenameStrategy == FilenameStrategy.digest) {
+            candidate = layer.getDigest();
+        } else {
+            final String title = layer.title();
+            candidate = (title != null && !title.isEmpty()) ? title : layer.getDigest();
+        }
+        final int lastSep = Math.max(candidate.lastIndexOf('/'), candidate.lastIndexOf('\\'));
+        final String name = lastSep >= 0 ? candidate.substring(lastSep + 1) : candidate;
+        for (int i = 0; i < name.length(); i++) {
+            final char c = name.charAt(i);
+            if (c < 0x20 || c == 0x7F) {
+                throw new InvalidParameterException(
+                    "Refusing layer filename containing control characters: " + layer);
+            }
+        }
+        if (name.isEmpty() || name.contains("..") || name.startsWith(".")) {
+            throw new InvalidParameterException(
+                "Refusing unsafe layer filename: '" + name + "'");
+        }
+        if (name.length() > MAX_FILENAME_LEN) {
+            throw new InvalidParameterException(
+                "Layer filename exceeds " + MAX_FILENAME_LEN + " chars: '" + name + "'");
+        }
+        return name;
+    }
+}

--- a/src/main/java/me/itzg/helpers/oci/OciClient.java
+++ b/src/main/java/me/itzg/helpers/oci/OciClient.java
@@ -1,0 +1,367 @@
+package me.itzg.helpers.oci;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.McImageHelper;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.get.ExtendedRequestRetryStrategy;
+import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.oci.RegistryAuthJson.BasicCredentials;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.util.Timeout;
+
+@Slf4j
+public class OciClient implements AutoCloseable {
+
+    private static final String ACCEPT_MANIFESTS =
+        OciManifest.MEDIA_TYPE_OCI + "," + OciManifest.MEDIA_TYPE_IMAGE_MANIFEST_V2;
+
+    private static final ObjectMapper MAPPER = ObjectMappers.defaultMapper();
+
+    private static final int MAX_REDIRECTS = 8;
+    private static final Timeout CONNECT_TIMEOUT = Timeout.ofSeconds(10);
+    // Response timeout is time-to-first-byte; large blob bodies stream fine after that
+    private static final Timeout RESPONSE_TIMEOUT = Timeout.ofSeconds(60);
+
+    private final CloseableHttpClient http;
+    private final RegistryAuthJson auths;
+    private final String scheme;
+    private final Map<String, String> tokenCache = new HashMap<>();
+
+    public OciClient(RegistryAuthJson auths) {
+        this(auths, "https");
+    }
+
+    // Visible for tests so they can run against a plain-HTTP WireMock registry
+    OciClient(RegistryAuthJson auths, String scheme) {
+        this.auths = auths;
+        this.scheme = scheme;
+        // Redirects are walked manually so the Authorization header is not
+        // forwarded to CDN pre-signed URLs (GHCR 307s to Azure Blob Storage).
+        this.http = HttpClients.custom()
+            .setUserAgent("itzg/mc-image-helper/" + McImageHelper.getVersion() + " (cmd=install-oci-pack)")
+            .setRetryStrategy(new ExtendedRequestRetryStrategy(3, 1))
+            .setDefaultRequestConfig(RequestConfig.custom()
+                .setRedirectsEnabled(false)
+                .setConnectTimeout(CONNECT_TIMEOUT)
+                .setResponseTimeout(RESPONSE_TIMEOUT)
+                .build())
+            .build();
+    }
+
+    public OciManifest fetchManifest(OciReference ref) {
+        final URI uri = URI.create(String.format("%s://%s/v2/%s/manifests/%s",
+            scheme, ref.getRegistry(), ref.getRepository(), ref.identifier()));
+        log.debug("Fetching manifest {}", uri);
+
+        try (CloseableHttpResponse response = followRedirects(uri, ref, ACCEPT_MANIFESTS)) {
+            final int status = response.getCode();
+            if (status != 200) {
+                throw new GenericException(String.format(
+                    "Failed to fetch OCI manifest %s: HTTP %d %s",
+                    ref, status, response.getReasonPhrase()));
+            }
+            final String contentType = contentTypeMime(response);
+            if (isImageIndex(contentType)) {
+                throw new GenericException(String.format(
+                    "OCI reference %s resolved to an image index (%s); "
+                        + "supply a per-platform manifest digest instead",
+                    ref, contentType));
+            }
+            final HttpEntity entity = response.getEntity();
+            if (entity == null) {
+                throw new GenericException("OCI manifest response had no body: " + ref);
+            }
+            try (InputStream in = entity.getContent()) {
+                final JsonNode tree = MAPPER.readTree(in);
+                if (tree.has("manifests") && !tree.has("layers")) {
+                    throw new GenericException(String.format(
+                        "OCI reference %s resolved to an image index; "
+                            + "supply a per-platform manifest digest instead", ref));
+                }
+                return MAPPER.treeToValue(tree, OciManifest.class);
+            }
+        } catch (IOException e) {
+            throw new GenericException("Failed to read OCI manifest " + ref, e);
+        }
+    }
+
+    public void downloadBlob(OciReference ref, String digest, Path target) {
+        if (Files.isRegularFile(target) && verifyExisting(target, digest)) {
+            log.debug("Layer {} already on disk at {}; skipping download", digest, target);
+            return;
+        }
+        final URI uri = URI.create(String.format("%s://%s/v2/%s/blobs/%s",
+            scheme, ref.getRegistry(), ref.getRepository(), digest));
+        log.debug("Downloading blob {}", uri);
+
+        try (CloseableHttpResponse response = followRedirects(uri, ref, null)) {
+            final int status = response.getCode();
+            if (status != 200) {
+                throw new GenericException(String.format(
+                    "Failed to download OCI blob %s: HTTP %d %s",
+                    digest, status, response.getReasonPhrase()));
+            }
+            final HttpEntity entity = response.getEntity();
+            if (entity == null) {
+                throw new GenericException("OCI blob response had no body: " + digest);
+            }
+            Files.createDirectories(target.getParent());
+            final MessageDigest sha = newSha256();
+            try (InputStream in = entity.getContent();
+                 OutputStream out = Files.newOutputStream(target)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    sha.update(buf, 0, n);
+                    out.write(buf, 0, n);
+                }
+            }
+            final String actual = "sha256:" + toHex(sha.digest());
+            if (!actual.equalsIgnoreCase(digest)) {
+                Files.deleteIfExists(target);
+                throw new GenericException(String.format(
+                    "Digest mismatch for OCI blob: expected %s, got %s",
+                    digest, actual));
+            }
+        } catch (IOException e) {
+            throw new GenericException("Failed to download OCI blob " + digest, e);
+        }
+    }
+
+    private CloseableHttpResponse followRedirects(URI startUri, OciReference ref, String accept)
+        throws IOException {
+        URI current = startUri;
+        boolean firstHop = true;
+        for (int i = 0; i < MAX_REDIRECTS; i++) {
+            final HttpGet request = new HttpGet(current);
+            if (firstHop && accept != null) {
+                request.setHeader(HttpHeaders.ACCEPT, accept);
+            }
+            final CloseableHttpResponse response = firstHop
+                ? executeWithAuth(request, ref)
+                : http.execute(request);
+            final int status = response.getCode();
+            if (status >= 300 && status < 400) {
+                final String location = headerValue(response, "Location");
+                response.close();
+                if (location == null || location.isEmpty()) {
+                    throw new GenericException(String.format(
+                        "Registry returned HTTP %d with no Location header for %s",
+                        status, current));
+                }
+                final URI next = current.resolve(location);
+                log.debug("Following redirect ({} -> {})", status, next);
+                current = next;
+                firstHop = false;
+                continue;
+            }
+            return response;
+        }
+        throw new GenericException("Exceeded redirect limit while fetching " + startUri);
+    }
+
+    @Override
+    public void close() throws IOException {
+        http.close();
+    }
+
+    private CloseableHttpResponse executeWithAuth(ClassicHttpRequest request, OciReference ref)
+        throws IOException {
+        final String scope = "repository:" + ref.getRepository() + ":pull";
+        final String username = auths.forHost(ref.getRegistry())
+            .map(BasicCredentials::getUsername)
+            .orElse("anonymous");
+        final String cacheKey = ref.getRegistry() + "|" + scope + "|" + username;
+        final String cachedToken = tokenCache.get(cacheKey);
+        if (cachedToken != null) {
+            request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + cachedToken);
+        }
+
+        final CloseableHttpResponse response = http.execute(request);
+        if (response.getCode() != 401) {
+            return response;
+        }
+        final String challenge = headerValue(response, "WWW-Authenticate");
+        response.close();
+
+        final Map<String, String> params = parseBearerChallenge(challenge);
+        final String realm = params.get("realm");
+        if (realm == null) {
+            throw new GenericException(String.format(
+                "Registry %s required auth but no Bearer challenge was provided",
+                ref.getRegistry()));
+        }
+        final String token = fetchToken(realm, params, ref);
+        tokenCache.put(cacheKey, token);
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        return http.execute(request);
+    }
+
+    private String fetchToken(String realm, Map<String, String> params, OciReference ref)
+        throws IOException {
+        final StringBuilder url = new StringBuilder(realm);
+        url.append(realm.contains("?") ? '&' : '?');
+        if (params.containsKey("service")) {
+            url.append("service=").append(URLEncoder.encode(params.get("service"), StandardCharsets.UTF_8))
+                .append('&');
+        }
+        url.append("scope=").append(URLEncoder.encode(
+            params.getOrDefault("scope", "repository:" + ref.getRepository() + ":pull"),
+            StandardCharsets.UTF_8));
+
+        final HttpGet tokenRequest = new HttpGet(url.toString());
+        tokenRequest.setHeader(HttpHeaders.ACCEPT, "application/json");
+        auths.forHost(ref.getRegistry()).ifPresent(creds -> applyBasic(tokenRequest, creds));
+
+        try (CloseableHttpResponse response = http.execute(tokenRequest)) {
+            final int status = response.getCode();
+            if (status != 200) {
+                throw new GenericException(String.format(
+                    "Token endpoint %s returned HTTP %d %s",
+                    realm, status, response.getReasonPhrase()));
+            }
+            final HttpEntity entity = response.getEntity();
+            if (entity == null) {
+                throw new GenericException("Token endpoint returned no body: " + realm);
+            }
+            try (InputStream in = entity.getContent()) {
+                final JsonNode body = MAPPER.readTree(in);
+                String token = body.path("token").asText(null);
+                if (token == null) {
+                    token = body.path("access_token").asText(null);
+                }
+                if (token == null) {
+                    throw new GenericException(
+                        "Token endpoint did not return a token field: " + realm);
+                }
+                return token;
+            }
+        }
+    }
+
+    private static void applyBasic(ClassicHttpRequest request, BasicCredentials creds) {
+        final String pair = creds.getUsername() + ":" + creds.getPassword();
+        final String b64 = Base64.getEncoder().encodeToString(pair.getBytes(StandardCharsets.UTF_8));
+        request.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + b64);
+    }
+
+    private static String headerValue(CloseableHttpResponse response, String name) {
+        return Arrays.stream(response.getHeaders(name))
+            .findFirst().map(Header::getValue).orElse(null);
+    }
+
+    private static String contentTypeMime(CloseableHttpResponse response) {
+        final String raw = headerValue(response, HttpHeaders.CONTENT_TYPE);
+        if (raw == null) {
+            return null;
+        }
+        try {
+            final ContentType ct = ContentType.parse(raw);
+            return ct.getMimeType();
+        } catch (RuntimeException e) {
+            return raw;
+        }
+    }
+
+    private static boolean isImageIndex(String mimeType) {
+        return OciManifest.MEDIA_TYPE_OCI_INDEX.equalsIgnoreCase(mimeType)
+            || OciManifest.MEDIA_TYPE_IMAGE_INDEX_V2.equalsIgnoreCase(mimeType);
+    }
+
+    private static Map<String, String> parseBearerChallenge(String header) {
+        final Map<String, String> params = new HashMap<>();
+        if (header == null || !header.regionMatches(true, 0, "Bearer", 0, "Bearer".length())) {
+            return params;
+        }
+        final String body = header.substring("Bearer".length()).trim();
+        final StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+        for (int i = 0; i < body.length(); i++) {
+            final char c = body.charAt(i);
+            if (c == '"') {
+                inQuotes = !inQuotes;
+                continue;
+            }
+            if (c == ',' && !inQuotes) {
+                addParam(params, current.toString());
+                current.setLength(0);
+                continue;
+            }
+            current.append(c);
+        }
+        if (current.length() > 0) {
+            addParam(params, current.toString());
+        }
+        return params;
+    }
+
+    private static void addParam(Map<String, String> params, String pair) {
+        final int eq = pair.indexOf('=');
+        if (eq < 0) {
+            return;
+        }
+        params.put(pair.substring(0, eq).trim(), pair.substring(eq + 1).trim());
+    }
+
+    private static boolean verifyExisting(Path target, String expectedDigest) {
+        if (!"sha256:".regionMatches(true, 0, expectedDigest, 0, "sha256:".length())) {
+            return false;
+        }
+        try {
+            final MessageDigest sha = newSha256();
+            try (InputStream in = Files.newInputStream(target)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    sha.update(buf, 0, n);
+                }
+            }
+            return ("sha256:" + toHex(sha.digest())).equalsIgnoreCase(expectedDigest);
+        } catch (IOException e) {
+            log.debug("Could not verify existing layer at {}: {}", target, e.getMessage());
+            return false;
+        }
+    }
+
+    /** SHA-256 is JDK-guaranteed; treat absence as a JRE installation bug. */
+    private static MessageDigest newSha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 unavailable in this JRE", e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte b : bytes) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/me/itzg/helpers/oci/OciManifest.java
+++ b/src/main/java/me/itzg/helpers/oci/OciManifest.java
@@ -1,0 +1,40 @@
+package me.itzg.helpers.oci;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OciManifest {
+
+    public static final String MEDIA_TYPE_OCI = "application/vnd.oci.image.manifest.v1+json";
+    public static final String MEDIA_TYPE_IMAGE_MANIFEST_V2 =
+        "application/vnd.docker.distribution.manifest.v2+json";
+
+    public static final String MEDIA_TYPE_OCI_INDEX = "application/vnd.oci.image.index.v1+json";
+    public static final String MEDIA_TYPE_IMAGE_INDEX_V2 =
+        "application/vnd.docker.distribution.manifest.list.v2+json";
+
+    private int schemaVersion;
+    private String mediaType;
+    private String artifactType;
+    private List<OciLayer> layers;
+    private Map<String, String> annotations;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class OciLayer {
+        private String mediaType;
+        private String digest;
+        private long size;
+        private Map<String, String> annotations;
+
+        public String title() {
+            return annotations != null
+                ? annotations.get("org.opencontainers.image.title")
+                : null;
+        }
+    }
+}

--- a/src/main/java/me/itzg/helpers/oci/OciReference.java
+++ b/src/main/java/me/itzg/helpers/oci/OciReference.java
@@ -1,0 +1,93 @@
+package me.itzg.helpers.oci;
+
+import java.util.regex.Pattern;
+import lombok.Value;
+import me.itzg.helpers.errors.InvalidParameterException;
+
+@Value
+public class OciReference {
+
+    public static final String DEFAULT_REGISTRY = "docker.io";
+    public static final String DEFAULT_TAG = "latest";
+
+    private static final Pattern SHA256_DIGEST = Pattern.compile("sha256:[0-9a-fA-F]{64}");
+
+    String registry;
+    String repository;
+    String tag;
+    String digest;
+
+    public static OciReference parse(String raw) {
+        if (raw == null || raw.isEmpty()) {
+            throw new InvalidParameterException("OCI reference must not be empty");
+        }
+        String value = raw;
+        if (value.startsWith("oci://")) {
+            value = value.substring("oci://".length());
+        }
+
+        String digest = null;
+        final int atIdx = value.lastIndexOf('@');
+        if (atIdx >= 0) {
+            digest = value.substring(atIdx + 1);
+            value = value.substring(0, atIdx);
+            if (!SHA256_DIGEST.matcher(digest).matches()) {
+                throw new InvalidParameterException(
+                    "Digest must match sha256:<64 hex chars> in OCI reference: " + raw);
+            }
+        }
+
+        // The colon separating tag is always after the last slash
+        // (registry hosts can contain colons for ports, e.g. localhost:5000/foo).
+        String tag = null;
+        final int lastSlash = value.lastIndexOf('/');
+        final int colonIdx = value.indexOf(':', Math.max(0, lastSlash));
+        if (colonIdx > 0) {
+            tag = value.substring(colonIdx + 1);
+            value = value.substring(0, colonIdx);
+        }
+
+        // A registry is recognised when the first segment contains a dot,
+        // a colon, or is "localhost".
+        final String registry;
+        final String repository;
+        final int slash = value.indexOf('/');
+        if (slash > 0) {
+            final String firstSegment = value.substring(0, slash);
+            if (firstSegment.contains(".") || firstSegment.contains(":")
+                || firstSegment.equals("localhost")) {
+                registry = firstSegment;
+                repository = value.substring(slash + 1);
+            } else {
+                registry = DEFAULT_REGISTRY;
+                repository = value;
+            }
+        } else {
+            registry = DEFAULT_REGISTRY;
+            repository = value;
+        }
+
+        if (repository.isEmpty()) {
+            throw new InvalidParameterException(
+                "OCI reference is missing a repository name: " + raw);
+        }
+
+        if (digest == null && tag == null) {
+            tag = DEFAULT_TAG;
+        }
+
+        return new OciReference(registry, repository, tag, digest);
+    }
+
+    public String identifier() {
+        return digest != null ? digest : tag;
+    }
+
+    @Override
+    public String toString() {
+        if (digest != null) {
+            return registry + "/" + repository + "@" + digest;
+        }
+        return registry + "/" + repository + ":" + tag;
+    }
+}

--- a/src/main/java/me/itzg/helpers/oci/RegistryAuthJson.java
+++ b/src/main/java/me/itzg/helpers/oci/RegistryAuthJson.java
@@ -1,0 +1,123 @@
+package me.itzg.helpers.oci;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RegistryAuthJson {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Map<String, BasicCredentials> byHost;
+
+    private RegistryAuthJson(Map<String, BasicCredentials> byHost) {
+        this.byHost = byHost;
+    }
+
+    public static RegistryAuthJson load(Path explicitPath) {
+        final Path path = explicitPath != null
+            ? explicitPath
+            : defaultPath();
+        if (path == null || !Files.isReadable(path)) {
+            log.debug("No registry auth file readable at {}", path);
+            return empty();
+        }
+        try {
+            final JsonNode root = MAPPER.readTree(path.toFile());
+            final JsonNode auths = root.path("auths");
+            final Map<String, BasicCredentials> hosts = new TreeMap<>();
+            if (auths.isObject()) {
+                final Iterator<Map.Entry<String, JsonNode>> it = auths.fields();
+                while (it.hasNext()) {
+                    final Map.Entry<String, JsonNode> entry = it.next();
+                    parseEntry(entry.getValue())
+                        .ifPresent(creds -> hosts.put(normaliseHost(entry.getKey()), creds));
+                }
+            }
+            log.debug("Loaded credentials for {} host(s) from {}", hosts.size(), path);
+            return new RegistryAuthJson(hosts);
+        } catch (IOException e) {
+            log.warn("Failed to parse registry auth file at {}: {}", path, e.getMessage());
+            return empty();
+        }
+    }
+
+    public static RegistryAuthJson empty() {
+        return new RegistryAuthJson(java.util.Collections.emptyMap());
+    }
+
+    public Optional<BasicCredentials> forHost(String host) {
+        return Optional.ofNullable(byHost.get(normaliseHost(host)));
+    }
+
+    private static Path defaultPath() {
+        final String home = System.getProperty("user.home");
+        if (home == null) {
+            return null;
+        }
+        final Path containersAuth = Paths.get(home, ".config", "containers", "auth.json");
+        if (Files.isReadable(containersAuth)) {
+            return containersAuth;
+        }
+        return Paths.get(home, ".docker", "config.json");
+    }
+
+    private static String normaliseHost(String host) {
+        if ("index.docker.io".equals(host) || "https://index.docker.io/v1/".equals(host)) {
+            return "docker.io";
+        }
+        String h = host;
+        final int proto = h.indexOf("://");
+        if (proto >= 0) {
+            h = h.substring(proto + 3);
+        }
+        final int slash = h.indexOf('/');
+        if (slash >= 0) {
+            h = h.substring(0, slash);
+        }
+        return h.toLowerCase();
+    }
+
+    private static Optional<BasicCredentials> parseEntry(JsonNode entry) {
+        final String authBlob = entry.path("auth").asText(null);
+        if (authBlob != null && !authBlob.isEmpty()) {
+            try {
+                final String decoded = new String(Base64.getDecoder().decode(authBlob));
+                final int colon = decoded.indexOf(':');
+                if (colon > 0) {
+                    return Optional.of(new BasicCredentials(
+                        decoded.substring(0, colon),
+                        decoded.substring(colon + 1)
+                    ));
+                }
+            } catch (IllegalArgumentException ignored) {
+                // fall through and try username/password fields
+            }
+        }
+        final String username = entry.path("username").asText(null);
+        final String password = entry.path("password").asText(null);
+        if (username != null && password != null) {
+            return Optional.of(new BasicCredentials(username, password));
+        }
+        return Optional.empty();
+    }
+
+    @Value
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BasicCredentials {
+        String username;
+        String password;
+    }
+}

--- a/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
+++ b/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
@@ -1,0 +1,408 @@
+package me.itzg.helpers.oci;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.absent;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine.ExitCode;
+
+@WireMockTest
+class InstallOciPackCommandTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void pullsLayersInManifestOrderAndPrintsPaths(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "shared base layer content".getBytes(StandardCharsets.UTF_8);
+        final byte[] overlayLayer = "tech overlay content".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+        final String overlayDigest = sha256(overlayLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/pack";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, overlayDigest, overlayLayer.length));
+        stubBlob(repository, baseDigest, baseLayer);
+        stubBlob(repository, overlayDigest, overlayLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
+        cmd.setScheme("http");
+
+        final Integer exit = cmd.call();
+
+        assertThat(exit).isEqualTo(ExitCode.OK);
+
+        final Path baseFile = stage.resolve("base.tar.gz");
+        final Path overlayFile = stage.resolve("tech.tar.gz");
+        assertThat(baseFile).exists().hasBinaryContent(baseLayer);
+        assertThat(overlayFile).exists().hasBinaryContent(overlayLayer);
+
+        final String[] printedLines = stdout.toString(StandardCharsets.UTF_8.name()).split("\\R");
+        assertThat(printedLines).hasSize(2);
+        assertThat(Path.of(printedLines[0])).isEqualTo(baseFile.toAbsolutePath());
+        assertThat(Path.of(printedLines[1])).isEqualTo(overlayFile.toAbsolutePath());
+    }
+
+    @Test
+    void writesLayerListFileForScriptedConsumers(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "shared base".getBytes(StandardCharsets.UTF_8);
+        final byte[] overlayLayer = "overlay".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+        final String overlayDigest = sha256(overlayLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/listed";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, overlayDigest, overlayLayer.length));
+        stubBlob(repository, baseDigest, baseLayer);
+        stubBlob(repository, overlayDigest, overlayLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        final Path layerList = tempDir.resolve("nested/layers.txt");
+        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.layerListFile = layerList;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
+        cmd.setScheme("http");
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+
+        assertThat(layerList).exists();
+        assertThat(Files.readAllLines(layerList))
+            .containsExactly(
+                stage.resolve("base.tar.gz").toAbsolutePath().toString(),
+                stage.resolve("tech.tar.gz").toAbsolutePath().toString()
+            );
+        assertThat(stdout.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    }
+
+    @Test
+    void skipsRedownloadWhenLayerAlreadyOnDisk(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "already cached locally".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/cached";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, null, 0));
+        stubBlob(repository, baseDigest, baseLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        Files.createDirectories(stage);
+        Files.write(stage.resolve("base.tar.gz"), baseLayer);
+
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+
+        verify(0, com.github.tomakehurst.wiremock.client.WireMock
+            .getRequestedFor(urlPathEqualTo("/v2/" + repository + "/blobs/" + baseDigest)));
+    }
+
+    @Test
+    void rejectsImageIndexByContentType(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) {
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/multiarch";
+
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/manifests/v1"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/vnd.oci.image.index.v1+json")
+                .withBody(buildImageIndex())));
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(GenericException.class)
+            .hasMessageContaining("image index");
+    }
+
+    @Test
+    void rejectsImageIndexByJsonBodyWhenContentTypeIsMisleading(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) {
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/multiarch-mislabelled";
+
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/manifests/v1"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(buildImageIndex())));
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(GenericException.class)
+            .hasMessageContaining("image index");
+    }
+
+    @Test
+    void rejectsLayerWithControlCharsInTitle(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] layer = "x".getBytes(StandardCharsets.UTF_8);
+        final String digest = sha256(layer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/nasty-title";
+
+        final ObjectNode manifest = MAPPER.createObjectNode();
+        manifest.put("schemaVersion", 2);
+        manifest.put("mediaType", "application/vnd.oci.image.manifest.v1+json");
+        final ArrayNode layers = manifest.putArray("layers");
+        final ObjectNode l = layers.addObject();
+        l.put("mediaType", "application/octet-stream");
+        l.put("digest", digest);
+        l.put("size", layer.length);
+        final String unsafeTitle = "evil" + (char) 0x09 + "name.tar.gz";
+        l.putObject("annotations")
+            .put("org.opencontainers.image.title", unsafeTitle);
+
+        stubManifest(repository, "v1", manifest.toString());
+        stubBlob(repository, digest, layer);
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining("control characters");
+    }
+
+    @Test
+    void completesBearerChallengeFlow(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] layer = "bearer-protected layer".getBytes(StandardCharsets.UTF_8);
+        final String digest = sha256(layer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/private";
+        final String tokenPath = "/auth/token";
+        final String tokenValue = "fake-bearer-token-12345";
+        final String bearerHeader = "Bearer " + tokenValue;
+
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/manifests/v1"))
+            .withHeader("Authorization", absent())
+            .willReturn(aResponse()
+                .withStatus(401)
+                .withHeader("WWW-Authenticate",
+                    "Bearer realm=\"" + wm.getHttpBaseUrl() + tokenPath + "\","
+                        + "service=\"test-registry\","
+                        + "scope=\"repository:" + repository + ":pull\"")));
+
+        final ObjectNode tokenBody = MAPPER.createObjectNode();
+        tokenBody.put("token", tokenValue);
+        stubFor(get(urlPathEqualTo(tokenPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(tokenBody.toString())));
+
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/manifests/v1"))
+            .withHeader("Authorization", equalTo(bearerHeader))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+                .withBody(buildManifest(digest, layer.length, null, 0))));
+
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/blobs/" + digest))
+            .withHeader("Authorization", equalTo(bearerHeader))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/octet-stream")
+                .withBody(layer)));
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+        assertThat(stage.resolve("base.tar.gz")).exists().hasBinaryContent(layer);
+
+        verify(1, getRequestedFor(urlPathEqualTo(tokenPath)));
+    }
+
+    @Test
+    void rejectsLayerOnDigestMismatch(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws NoSuchAlgorithmException {
+        final byte[] truth = "real layer bytes".getBytes(StandardCharsets.UTF_8);
+        final byte[] tampered = "tampered registry response".getBytes(StandardCharsets.UTF_8);
+        final String advertisedDigest = sha256(truth);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/tampered";
+
+        stubManifest(repository, "v1",
+            buildManifest(advertisedDigest, truth.length, null, 0));
+        stubBlob(repository, advertisedDigest, tampered);
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(GenericException.class)
+            .hasMessageContaining("Digest mismatch");
+    }
+
+    private static String sha256(byte[] bytes) throws NoSuchAlgorithmException {
+        final MessageDigest md = MessageDigest.getInstance("SHA-256");
+        final byte[] hash = md.digest(bytes);
+        final StringBuilder sb = new StringBuilder("sha256:");
+        for (final byte b : hash) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    private static String buildManifest(String baseDigest, int baseSize,
+                                        String overlayDigest, int overlaySize) {
+        final ObjectNode manifest = MAPPER.createObjectNode();
+        manifest.put("schemaVersion", 2);
+        manifest.put("mediaType", "application/vnd.oci.image.manifest.v1+json");
+        manifest.put("artifactType", "application/vnd.itzg.minecraft.modpack.v1+json");
+        final ObjectNode config = manifest.putObject("config");
+        config.put("mediaType", "application/vnd.oci.empty.v1+json");
+        config.put("digest",
+            "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a");
+        config.put("size", 2);
+
+        final ArrayNode layers = manifest.putArray("layers");
+        final ObjectNode layer1 = layers.addObject();
+        layer1.put("mediaType", "application/vnd.itzg.minecraft.modpack.layer.v1.tar+gzip");
+        layer1.put("digest", baseDigest);
+        layer1.put("size", baseSize);
+        layer1.putObject("annotations")
+            .put("org.opencontainers.image.title", "base.tar.gz");
+
+        if (overlayDigest != null) {
+            final ObjectNode layer2 = layers.addObject();
+            layer2.put("mediaType", "application/vnd.itzg.minecraft.modpack.layer.v1.tar+gzip");
+            layer2.put("digest", overlayDigest);
+            layer2.put("size", overlaySize);
+            layer2.putObject("annotations")
+                .put("org.opencontainers.image.title", "tech.tar.gz");
+        }
+
+        return manifest.toString();
+    }
+
+    private static String buildImageIndex() {
+        final ObjectNode index = MAPPER.createObjectNode();
+        index.put("schemaVersion", 2);
+        index.put("mediaType", "application/vnd.oci.image.index.v1+json");
+        final ArrayNode manifests = index.putArray("manifests");
+        final ObjectNode m = manifests.addObject();
+        m.put("mediaType", "application/vnd.oci.image.manifest.v1+json");
+        m.put("digest",
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000");
+        m.put("size", 123);
+        m.putObject("platform")
+            .put("architecture", "amd64")
+            .put("os", "linux");
+        return index.toString();
+    }
+
+    private static void stubManifest(String repository, String tag, String body) {
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/manifests/" + tag))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+                .withBody(body)));
+    }
+
+    private static void stubBlob(String repository, String digest, byte[] body) {
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/blobs/" + digest))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/octet-stream")
+                .withBody(body)));
+    }
+}

--- a/src/test/java/me/itzg/helpers/oci/OciReferenceTest.java
+++ b/src/test/java/me/itzg/helpers/oci/OciReferenceTest.java
@@ -1,0 +1,100 @@
+package me.itzg.helpers.oci;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import me.itzg.helpers.errors.InvalidParameterException;
+import org.junit.jupiter.api.Test;
+
+class OciReferenceTest {
+
+    @Test
+    void parsesGhcrReferenceWithTag() {
+        final OciReference ref = OciReference.parse("ghcr.io/some-org/modpack/tech:latest");
+
+        assertThat(ref.getRegistry()).isEqualTo("ghcr.io");
+        assertThat(ref.getRepository()).isEqualTo("some-org/modpack/tech");
+        assertThat(ref.getTag()).isEqualTo("latest");
+        assertThat(ref.getDigest()).isNull();
+    }
+
+    @Test
+    void toleratesOciScheme() {
+        final OciReference ref = OciReference.parse("oci://ghcr.io/owner/pack:v1");
+
+        assertThat(ref.getRegistry()).isEqualTo("ghcr.io");
+        assertThat(ref.getRepository()).isEqualTo("owner/pack");
+        assertThat(ref.getTag()).isEqualTo("v1");
+    }
+
+    @Test
+    void parsesDigestReference() {
+        final OciReference ref = OciReference.parse(
+            "ghcr.io/owner/pack@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+        assertThat(ref.getDigest()).startsWith("sha256:");
+        assertThat(ref.getTag()).isNull();
+        assertThat(ref.identifier()).isEqualTo(ref.getDigest());
+    }
+
+    @Test
+    void prefersDigestOverTagWhenBothAreGiven() {
+        final OciReference ref = OciReference.parse(
+            "ghcr.io/owner/pack:v1@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+
+        assertThat(ref.getTag()).isEqualTo("v1");
+        assertThat(ref.getDigest()).startsWith("sha256:");
+        assertThat(ref.identifier()).isEqualTo(ref.getDigest());
+    }
+
+    @Test
+    void defaultsRegistryWhenNoneInRef() {
+        final OciReference ref = OciReference.parse("library/alpine:3");
+
+        assertThat(ref.getRegistry()).isEqualTo("docker.io");
+        assertThat(ref.getRepository()).isEqualTo("library/alpine");
+    }
+
+    @Test
+    void defaultsTagWhenNoneInRef() {
+        final OciReference ref = OciReference.parse("ghcr.io/owner/pack");
+
+        assertThat(ref.getTag()).isEqualTo("latest");
+    }
+
+    @Test
+    void recognisesPortedLocalhostRegistry() {
+        final OciReference ref = OciReference.parse("localhost:5000/some/repo:v1");
+
+        assertThat(ref.getRegistry()).isEqualTo("localhost:5000");
+        assertThat(ref.getRepository()).isEqualTo("some/repo");
+        assertThat(ref.getTag()).isEqualTo("v1");
+    }
+
+    @Test
+    void rejectsEmptyReference() {
+        assertThatThrownBy(() -> OciReference.parse(""))
+            .isInstanceOf(InvalidParameterException.class);
+        assertThatThrownBy(() -> OciReference.parse(null))
+            .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    void rejectsNonSha256Digests() {
+        assertThatThrownBy(() -> OciReference.parse("ghcr.io/owner/pack@md5:abc"))
+            .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    void rejectsTruncatedSha256Digest() {
+        assertThatThrownBy(() -> OciReference.parse("ghcr.io/owner/pack@sha256:abc"))
+            .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    void rejectsNonHexSha256Digest() {
+        assertThatThrownBy(() -> OciReference.parse(
+            "ghcr.io/owner/pack@sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"))
+            .isInstanceOf(InvalidParameterException.class);
+    }
+}


### PR DESCRIPTION
Adds an `install-oci-pack` subcommand that pulls OCI artifacts from any distribution-spec registry and writes layer blobs to disk in manifest order, for the `GENERIC_PACK[S]` handler in docker-minecraft-server.

The [ORAS Java SDK](https://github.com/oras-project/oras-java) requires Java 17+ and this project targets Java 8, so this is a minimal client instead covering the distribution-spec surface needed for artifact pulls: bearer challenge/response auth with token caching, manual redirect handling, and streaming SHA-256 verification.

Reads credentials from `~/.config/containers/auth.json` or `~/.docker/config.json`. No credHelper support.

The output directory acts as a content-addressed cache, so shared layers across sibling artifacts are only downloaded once.

Ref: https://github.com/itzg/docker-minecraft-server/issues/4038