### PR TITLE
Add install-oci-pack command (ORAS SDK)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,14 +45,14 @@ jar {
 }
 
 java {
-  // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 11
+  // Specify to gradle that the project expects to be built with java 21, but produce output compatible with Java 17
   toolchain {
     languageVersion = JavaLanguageVersion.of(21)
   }
 }
 // https://docs.gradle.org/current/userguide/toolchains.html#sec:release-flag-toolchain
 tasks.withType(JavaCompile).configureEach {
-  options.release = 11
+  options.release = 17
 }
 
 test {
@@ -115,6 +115,7 @@ dependencies {
   implementation 'org.apache.maven:maven-artifact:3.9.15'
   implementation 'commons-codec:commons-codec:1.22.0'
   implementation 'org.jetbrains:annotations:26.1.0'
+  implementation 'land.oras:oras-java-sdk:0.6.0'
 
   // https://commons.apache.org/proper/commons-compress/zip.html
   // For IMPLODE compression used by some CurseForge modpacks

--- a/src/main/java/me/itzg/helpers/McImageHelper.java
+++ b/src/main/java/me/itzg/helpers/McImageHelper.java
@@ -32,6 +32,7 @@ import me.itzg.helpers.modrinth.InstallModrinthModpackCommand;
 import me.itzg.helpers.modrinth.ModrinthCommand;
 import me.itzg.helpers.modrinth.VersionFromModrinthProjectsCommand;
 import me.itzg.helpers.mvn.MavenDownloadCommand;
+import me.itzg.helpers.oci.InstallOciPackCommand;
 import me.itzg.helpers.paper.InstallPaperCommand;
 import me.itzg.helpers.patch.PatchCommand;
 import me.itzg.helpers.properties.SetPropertiesCommand;
@@ -80,6 +81,7 @@ import picocli.CommandLine.Spec;
         InstallForgeCommand.class,
         InstallModrinthModpackCommand.class,
         InstallNeoForgeCommand.class,
+        InstallOciPackCommand.class,
         InstallPaperCommand.class,
         InstallPurpurCommand.class,
         InstallQuiltCommand.class,

--- a/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
+++ b/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
@@ -114,6 +114,7 @@ public class InstallOciPackCommand implements Callable<Integer> {
                         throw new GenericException(
                             "Failed to download OCI layer " + digest + ": " + e.getMessage(), e);
                     }
+                    verifyDownloaded(target, digest);
                 }
                 written.add(target);
             }
@@ -214,19 +215,56 @@ public class InstallOciPackCommand implements Callable<Integer> {
             return false;
         }
         try {
-            final MessageDigest sha = MessageDigest.getInstance("SHA-256");
-            try (InputStream in = Files.newInputStream(target)) {
-                final byte[] buf = new byte[8192];
-                int n;
-                while ((n = in.read(buf)) > 0) {
-                    sha.update(buf, 0, n);
-                }
-            }
-            return ("sha256:" + toHex(sha.digest())).equalsIgnoreCase(expectedDigest);
-        } catch (IOException | NoSuchAlgorithmException e) {
+            return computeSha256(target).equalsIgnoreCase(expectedDigest);
+        } catch (IOException e) {
             log.debug("Could not verify existing layer at {}: {}", target, e.getMessage());
             return false;
         }
+    }
+
+    // The ORAS SDK only verifies blob bytes against the Docker-Content-Digest
+    // response header, and silently skips verification when that header is
+    // absent (the OCI distribution spec marks it SHOULD, not MUST). Recompute
+    // the digest ourselves against the manifest's declared value so a
+    // misbehaving registry or stripping proxy cannot serve us tampered bytes.
+    private static void verifyDownloaded(Path target, String expectedDigest) {
+        if (!"sha256:".regionMatches(true, 0, expectedDigest, 0, "sha256:".length())) {
+            return;
+        }
+        final String actual;
+        try {
+            actual = computeSha256(target);
+        } catch (IOException e) {
+            throw new GenericException(
+                "Failed to verify digest of " + target + ": " + e.getMessage(), e);
+        }
+        if (!actual.equalsIgnoreCase(expectedDigest)) {
+            try {
+                Files.deleteIfExists(target);
+            } catch (IOException ignored) {
+                // best-effort cleanup
+            }
+            throw new GenericException(String.format(
+                "Digest mismatch for OCI blob: expected %s, got %s",
+                expectedDigest, actual));
+        }
+    }
+
+    private static String computeSha256(Path target) throws IOException {
+        final MessageDigest sha;
+        try {
+            sha = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError("SHA-256 unavailable in this JRE", e);
+        }
+        try (InputStream in = Files.newInputStream(target)) {
+            final byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) > 0) {
+                sha.update(buf, 0, n);
+            }
+        }
+        return "sha256:" + toHex(sha.digest());
     }
 
     private static String toHex(byte[] bytes) {

--- a/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
+++ b/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -91,8 +90,8 @@ public class InstallOciPackCommand implements Callable<Integer> {
 
         Files.createDirectories(outputDirectory);
         final Registry registry = buildRegistry();
+        log.info("Resolving OCI artifact {}", cref);
         try {
-            log.info("Resolving OCI artifact {}", cref);
             final Manifest manifest = registry.getManifest(cref);
             if (manifest.getLayers() == null || manifest.getLayers().isEmpty()) {
                 throw new GenericException("OCI artifact " + cref + " declares no layers");
@@ -102,7 +101,11 @@ public class InstallOciPackCommand implements Callable<Integer> {
             for (final Layer layer : manifest.getLayers()) {
                 final Path target = outputDirectory.resolve(filenameFor(layer));
                 final String digest = layer.getDigest();
-                if (digest != null && Files.isRegularFile(target) && verifyExisting(target, digest)) {
+                if (digest == null) {
+                    throw new GenericException(
+                        "OCI artifact " + cref + " has a layer without a digest");
+                }
+                if (Files.isRegularFile(target) && verifyExisting(target, digest)) {
                     log.debug("Layer {} already on disk at {}; skipping download", digest, target);
                 } else {
                     try {
@@ -158,11 +161,11 @@ public class InstallOciPackCommand implements Callable<Integer> {
         } else {
             final String home = System.getProperty("user.home");
             if (home != null) {
-                final Path containersAuth = Paths.get(home, ".config", "containers", "auth.json");
+                final Path containersAuth = Path.of(home, ".config", "containers", "auth.json");
                 if (Files.isReadable(containersAuth)) {
                     config = containersAuth;
                 } else {
-                    final Path def = Paths.get(home, ".docker", "config.json");
+                    final Path def = Path.of(home, ".docker", "config.json");
                     if (Files.isReadable(def)) {
                         config = def;
                     }
@@ -190,7 +193,7 @@ public class InstallOciPackCommand implements Callable<Integer> {
             final String title = layerTitle(layer);
             candidate = title != null && !title.isBlank() ? title : layer.getDigest();
         }
-        final Path p = Paths.get(candidate).getFileName();
+        final Path p = Path.of(candidate).getFileName();
         if (p == null) {
             throw new InvalidParameterException(
                 "Could not derive a filename from layer: " + layer);
@@ -199,11 +202,11 @@ public class InstallOciPackCommand implements Callable<Integer> {
     }
 
     private static String layerTitle(Layer layer) {
-        final Map<String, String> ann = layer.getAnnotations();
-        if (ann == null) {
+        final Map<String, String> annotations = layer.getAnnotations();
+        if (annotations == null) {
             return null;
         }
-        return ann.get("org.opencontainers.image.title");
+        return annotations.get("org.opencontainers.image.title");
     }
 
     private static boolean verifyExisting(Path target, String expectedDigest) {

--- a/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
+++ b/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
@@ -3,7 +3,6 @@ package me.itzg.helpers.oci;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,6 +24,7 @@ import land.oras.auth.AuthStore;
 import land.oras.auth.AuthStoreAuthenticationProvider;
 import land.oras.auth.NoAuthProvider;
 import land.oras.exception.OrasException;
+import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
@@ -65,16 +65,17 @@ public class InstallOciPackCommand implements Callable<Integer> {
             + " When omitted, layer paths are also printed to stdout for interactive use.")
     Path layerListFile;
 
-    // Allows tests to capture stdout without intercepting the JVM's
-    @Setter
-    private PrintStream out = System.out;
-
-    // Visible for tests; production code always uses HTTPS
-    @Setter
-    String scheme = "https";
+    // Visible for tests so they can point at a plain-HTTP WireMock registry
+    @Setter(AccessLevel.PACKAGE)
+    boolean insecure;
 
     public enum FilenameStrategy {
+        /**
+         * Use the layer's {@code org.opencontainers.image.title} annotation,
+         * falling back to its digest when the annotation is absent.
+         */
         title,
+        /** Always use the layer's digest as the filename. */
         digest
     }
 
@@ -127,7 +128,7 @@ public class InstallOciPackCommand implements Callable<Integer> {
                 }
             } else {
                 for (final Path p : written) {
-                    out.println(p.toAbsolutePath());
+                    System.out.println(p.toAbsolutePath());
                 }
             }
         } catch (OrasException e) {
@@ -141,7 +142,7 @@ public class InstallOciPackCommand implements Callable<Integer> {
     private Registry buildRegistry() {
         final Registry.Builder b = Registry.builder()
             .withAuthProvider(resolveAuthProvider());
-        if ("http".equalsIgnoreCase(scheme)) {
+        if (insecure) {
             b.insecure();
         }
         return b.build();
@@ -187,7 +188,7 @@ public class InstallOciPackCommand implements Callable<Integer> {
             candidate = layer.getDigest();
         } else {
             final String title = layerTitle(layer);
-            candidate = (title != null && !title.isEmpty()) ? title : layer.getDigest();
+            candidate = title != null && !title.isBlank() ? title : layer.getDigest();
         }
         final Path p = Paths.get(candidate).getFileName();
         if (p == null) {

--- a/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
+++ b/src/main/java/me/itzg/helpers/oci/InstallOciPackCommand.java
@@ -1,0 +1,235 @@
+package me.itzg.helpers.oci;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import land.oras.ContainerRef;
+import land.oras.Layer;
+import land.oras.Manifest;
+import land.oras.Registry;
+import land.oras.auth.AuthProvider;
+import land.oras.auth.AuthStore;
+import land.oras.auth.AuthStoreAuthenticationProvider;
+import land.oras.auth.NoAuthProvider;
+import land.oras.exception.OrasException;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Option;
+
+@Command(name = "install-oci-pack",
+    description = "Pulls an OCI artifact and writes its layer blobs to disk in apply order",
+    mixinStandardHelpOptions = true)
+@Slf4j
+public class InstallOciPackCommand implements Callable<Integer> {
+
+    @Option(names = "--ref", required = true, paramLabel = "REF",
+        description = "OCI reference, e.g. ghcr.io/owner/pack:v1 or ghcr.io/owner/pack@sha256:..."
+            + "%nThe optional oci:// prefix is tolerated.")
+    String ref;
+
+    @Option(names = "--output-directory", required = true, paramLabel = "DIR",
+        description = "Directory where layer blobs are written. Acts as a content-addressed"
+            + " cache between invocations: layers whose digest already exists are not re-downloaded.")
+    Path outputDirectory;
+
+    @Option(names = "--auth-file", paramLabel = "FILE",
+        description = "Registry login JSON (root auths map). When unset, reads the default"
+            + " login file under the user home directory if present.")
+    Path authFile;
+
+    @Option(names = "--filename-strategy", defaultValue = "title",
+        description = "How to name layer files on disk. Valid values: ${COMPLETION-CANDIDATES}."
+            + "%nDefault: ${DEFAULT-VALUE}")
+    FilenameStrategy filenameStrategy;
+
+    @Option(names = "--layer-list-file", paramLabel = "FILE",
+        description = "Write each pulled layer's absolute path on its own line to this file,"
+            + " in manifest layer order. Suitable for `mapfile -t ... < FILE` in shell."
+            + " When omitted, layer paths are also printed to stdout for interactive use.")
+    Path layerListFile;
+
+    // Allows tests to capture stdout without intercepting the JVM's
+    @Setter
+    private PrintStream out = System.out;
+
+    // Visible for tests; production code always uses HTTPS
+    @Setter
+    String scheme = "https";
+
+    public enum FilenameStrategy {
+        title,
+        digest
+    }
+
+    @Override
+    public Integer call() throws IOException {
+        final ContainerRef cref;
+        try {
+            cref = ContainerRef.parse(ref);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidParameterException(
+                "Invalid OCI reference: " + ref + ": " + e.getMessage(), e);
+        }
+
+        Files.createDirectories(outputDirectory);
+        final Registry registry = buildRegistry();
+        try {
+            log.info("Resolving OCI artifact {}", cref);
+            final Manifest manifest = registry.getManifest(cref);
+            if (manifest.getLayers() == null || manifest.getLayers().isEmpty()) {
+                throw new GenericException("OCI artifact " + cref + " declares no layers");
+            }
+
+            final List<Path> written = new ArrayList<>(manifest.getLayers().size());
+            for (final Layer layer : manifest.getLayers()) {
+                final Path target = outputDirectory.resolve(filenameFor(layer));
+                final String digest = layer.getDigest();
+                if (digest != null && Files.isRegularFile(target) && verifyExisting(target, digest)) {
+                    log.debug("Layer {} already on disk at {}; skipping download", digest, target);
+                } else {
+                    try {
+                        registry.fetchBlob(cref.withDigest(digest), target);
+                    } catch (OrasException e) {
+                        throw new GenericException(
+                            "Failed to download OCI layer " + digest + ": " + e.getMessage(), e);
+                    }
+                }
+                written.add(target);
+            }
+
+            if (layerListFile != null) {
+                Files.createDirectories(layerListFile.toAbsolutePath().getParent());
+                try (BufferedWriter w = Files.newBufferedWriter(
+                    layerListFile, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING)) {
+                    for (final Path p : written) {
+                        w.write(p.toAbsolutePath().toString());
+                        w.newLine();
+                    }
+                }
+            } else {
+                for (final Path p : written) {
+                    out.println(p.toAbsolutePath());
+                }
+            }
+        } catch (OrasException e) {
+            throw new GenericException(
+                "Failed to pull OCI artifact " + cref + ": " + e.getMessage(), e);
+        }
+
+        return ExitCode.OK;
+    }
+
+    private Registry buildRegistry() {
+        final Registry.Builder b = Registry.builder()
+            .withAuthProvider(resolveAuthProvider());
+        if ("http".equalsIgnoreCase(scheme)) {
+            b.insecure();
+        }
+        return b.build();
+    }
+
+    // ORAS AuthStore.newStore() throws on empty or malformed login files
+    // (e.g. missing 'auths'); tests and minimal images often have no usable
+    // file, so fall back to anonymous pulls.
+    private AuthProvider resolveAuthProvider() {
+        Path config = null;
+        if (authFile != null && Files.isReadable(authFile)) {
+            config = authFile;
+        } else {
+            final String home = System.getProperty("user.home");
+            if (home != null) {
+                final Path containersAuth = Paths.get(home, ".config", "containers", "auth.json");
+                if (Files.isReadable(containersAuth)) {
+                    config = containersAuth;
+                } else {
+                    final Path def = Paths.get(home, ".docker", "config.json");
+                    if (Files.isReadable(def)) {
+                        config = def;
+                    }
+                }
+            }
+        }
+        if (config == null) {
+            return new NoAuthProvider();
+        }
+        try {
+            return new AuthStoreAuthenticationProvider(
+                AuthStore.newStore(Collections.singletonList(config)));
+        } catch (RuntimeException e) {
+            log.debug("Registry login file at {} not usable by ORAS ({}); using no auth",
+                config, e.getMessage());
+            return new NoAuthProvider();
+        }
+    }
+
+    private String filenameFor(Layer layer) {
+        final String candidate;
+        if (filenameStrategy == FilenameStrategy.digest) {
+            candidate = layer.getDigest();
+        } else {
+            final String title = layerTitle(layer);
+            candidate = (title != null && !title.isEmpty()) ? title : layer.getDigest();
+        }
+        final Path p = Paths.get(candidate).getFileName();
+        if (p == null) {
+            throw new InvalidParameterException(
+                "Could not derive a filename from layer: " + layer);
+        }
+        return p.toString();
+    }
+
+    private static String layerTitle(Layer layer) {
+        final Map<String, String> ann = layer.getAnnotations();
+        if (ann == null) {
+            return null;
+        }
+        return ann.get("org.opencontainers.image.title");
+    }
+
+    private static boolean verifyExisting(Path target, String expectedDigest) {
+        if (!"sha256:".regionMatches(true, 0, expectedDigest, 0, "sha256:".length())) {
+            return false;
+        }
+        try {
+            final MessageDigest sha = MessageDigest.getInstance("SHA-256");
+            try (InputStream in = Files.newInputStream(target)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = in.read(buf)) > 0) {
+                    sha.update(buf, 0, n);
+                }
+            }
+            return ("sha256:" + toHex(sha.digest())).equalsIgnoreCase(expectedDigest);
+        } catch (IOException | NoSuchAlgorithmException e) {
+            log.debug("Could not verify existing layer at {}: {}", target, e.getMessage());
+            return false;
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        final StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (final byte b : bytes) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
+++ b/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
@@ -176,6 +176,39 @@ class InstallOciPackCommandTest {
             .hasMessageContaining("Digest mismatch");
     }
 
+    @Test
+    void rejectsLayerWhenRegistryOmitsDigestHeader(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws NoSuchAlgorithmException {
+        final byte[] truth = "real layer bytes".getBytes(StandardCharsets.UTF_8);
+        final byte[] tampered = "tampered without header".getBytes(StandardCharsets.UTF_8);
+        final String advertisedDigest = sha256(truth);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/no-header";
+
+        stubManifest(repository, "v1",
+            buildManifest(advertisedDigest, truth.length, null, 0));
+        // Note: no Docker-Content-Digest header. The SDK skips its own
+        // validation in that case, so this test covers our end-to-end
+        // digest check against the manifest's declared value.
+        stubBlob(repository, advertisedDigest, tampered);
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setInsecure(true);
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(GenericException.class)
+            .hasMessageContaining("Digest mismatch");
+        // The tampered file should be cleaned up on mismatch
+        assertThat(stage.resolve("base.tar.gz")).doesNotExist();
+    }
+
     // Logback in tests writes to stdout, so strip those lines when asserting on command output
     private static String[] nonLogLines(String stdout) {
         return Arrays.stream(stdout.split("\n"))

--- a/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
+++ b/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
@@ -1,0 +1,252 @@
+package me.itzg.helpers.oci;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.head;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import me.itzg.helpers.errors.GenericException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine.ExitCode;
+
+@WireMockTest
+class InstallOciPackCommandTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void pullsLayersInManifestOrderAndPrintsPaths(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "shared base layer content".getBytes(StandardCharsets.UTF_8);
+        final byte[] overlayLayer = "tech overlay content".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+        final String overlayDigest = sha256(overlayLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/pack";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, overlayDigest, overlayLayer.length));
+        stubBlob(repository, baseDigest, baseLayer);
+        stubBlob(repository, overlayDigest, overlayLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
+        cmd.setScheme("http");
+
+        final Integer exit = cmd.call();
+
+        assertThat(exit).isEqualTo(ExitCode.OK);
+
+        final Path baseFile = stage.resolve("base.tar.gz");
+        final Path overlayFile = stage.resolve("tech.tar.gz");
+        assertThat(baseFile).exists().hasBinaryContent(baseLayer);
+        assertThat(overlayFile).exists().hasBinaryContent(overlayLayer);
+
+        final String[] printedLines = stdout.toString(StandardCharsets.UTF_8.name()).split("\\R");
+        assertThat(printedLines).hasSize(2);
+        assertThat(Path.of(printedLines[0])).isEqualTo(baseFile.toAbsolutePath());
+        assertThat(Path.of(printedLines[1])).isEqualTo(overlayFile.toAbsolutePath());
+    }
+
+    @Test
+    void writesLayerListFileForScriptedConsumers(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "shared base".getBytes(StandardCharsets.UTF_8);
+        final byte[] overlayLayer = "overlay".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+        final String overlayDigest = sha256(overlayLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/listed";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, overlayDigest, overlayLayer.length));
+        stubBlob(repository, baseDigest, baseLayer);
+        stubBlob(repository, overlayDigest, overlayLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        final Path layerList = tempDir.resolve("nested/layers.txt");
+        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.layerListFile = layerList;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
+        cmd.setScheme("http");
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+
+        assertThat(layerList).exists();
+        assertThat(Files.readAllLines(layerList))
+            .containsExactly(
+                stage.resolve("base.tar.gz").toAbsolutePath().toString(),
+                stage.resolve("tech.tar.gz").toAbsolutePath().toString()
+            );
+        assertThat(stdout.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    }
+
+    @Test
+    void skipsRedownloadWhenLayerAlreadyOnDisk(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws IOException, NoSuchAlgorithmException {
+        final byte[] baseLayer = "already cached locally".getBytes(StandardCharsets.UTF_8);
+        final String baseDigest = sha256(baseLayer);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/cached";
+
+        stubManifest(repository, "v1",
+            buildManifest(baseDigest, baseLayer.length, null, 0));
+        stubBlob(repository, baseDigest, baseLayer);
+
+        final Path stage = tempDir.resolve("stage");
+        Files.createDirectories(stage);
+        Files.write(stage.resolve("base.tar.gz"), baseLayer);
+
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+
+        verify(0, com.github.tomakehurst.wiremock.client.WireMock
+            .getRequestedFor(urlPathEqualTo("/v2/" + repository + "/blobs/" + baseDigest)));
+    }
+
+    @Test
+    void rejectsLayerOnDigestMismatch(
+        WireMockRuntimeInfo wm, @TempDir Path tempDir
+    ) throws NoSuchAlgorithmException {
+        final byte[] truth = "real layer bytes".getBytes(StandardCharsets.UTF_8);
+        final byte[] tampered = "tampered registry response".getBytes(StandardCharsets.UTF_8);
+        final String advertisedDigest = sha256(truth);
+
+        final URI base = URI.create(wm.getHttpBaseUrl());
+        final String registry = base.getHost() + ":" + base.getPort();
+        final String repository = "owner/tampered";
+
+        stubManifest(repository, "v1",
+            buildManifest(advertisedDigest, truth.length, null, 0));
+        // Server returns different bytes for the advertised digest; the
+        // Docker-Content-Digest header echoes the manifest's value so ORAS
+        // compares it against the actual payload and rejects the mismatch.
+        stubBlob(repository, advertisedDigest, tampered, advertisedDigest);
+
+        final Path stage = tempDir.resolve("stage");
+        final InstallOciPackCommand cmd = new InstallOciPackCommand();
+        cmd.ref = registry + "/" + repository + ":v1";
+        cmd.outputDirectory = stage;
+        cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
+        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
+        cmd.setScheme("http");
+
+        assertThatThrownBy(cmd::call)
+            .isInstanceOf(GenericException.class)
+            .hasMessageContaining("Digest mismatch");
+    }
+
+    private static String sha256(byte[] bytes) throws NoSuchAlgorithmException {
+        final MessageDigest md = MessageDigest.getInstance("SHA-256");
+        final byte[] hash = md.digest(bytes);
+        final StringBuilder sb = new StringBuilder("sha256:");
+        for (final byte b : hash) {
+            sb.append(String.format("%02x", b & 0xff));
+        }
+        return sb.toString();
+    }
+
+    private static String buildManifest(String baseDigest, int baseSize,
+                                        String overlayDigest, int overlaySize) {
+        final ObjectNode manifest = MAPPER.createObjectNode();
+        manifest.put("schemaVersion", 2);
+        manifest.put("mediaType", "application/vnd.oci.image.manifest.v1+json");
+        manifest.put("artifactType", "application/vnd.itzg.minecraft.modpack.v1+json");
+        final ObjectNode config = manifest.putObject("config");
+        config.put("mediaType", "application/vnd.oci.empty.v1+json");
+        config.put("digest",
+            "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a");
+        config.put("size", 2);
+
+        final ArrayNode layers = manifest.putArray("layers");
+        final ObjectNode layer1 = layers.addObject();
+        layer1.put("mediaType", "application/vnd.itzg.minecraft.modpack.layer.v1.tar+gzip");
+        layer1.put("digest", baseDigest);
+        layer1.put("size", baseSize);
+        layer1.putObject("annotations")
+            .put("org.opencontainers.image.title", "base.tar.gz");
+
+        if (overlayDigest != null) {
+            final ObjectNode layer2 = layers.addObject();
+            layer2.put("mediaType", "application/vnd.itzg.minecraft.modpack.layer.v1.tar+gzip");
+            layer2.put("digest", overlayDigest);
+            layer2.put("size", overlaySize);
+            layer2.putObject("annotations")
+                .put("org.opencontainers.image.title", "tech.tar.gz");
+        }
+
+        return manifest.toString();
+    }
+
+    private static void stubManifest(String repository, String tag, String body) {
+        final String path = "/v2/" + repository + "/manifests/" + tag;
+        final ResponseDefinitionBuilder ok = aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+            .withBody(body);
+        // land.oras issues HEAD before GET for manifests
+        stubFor(head(urlPathEqualTo(path)).willReturn(ok));
+        stubFor(get(urlPathEqualTo(path)).willReturn(ok));
+    }
+
+    private static void stubBlob(String repository, String digest, byte[] body) {
+        stubBlob(repository, digest, body, null);
+    }
+
+    private static void stubBlob(String repository, String digest, byte[] body,
+                                 String contentDigest) {
+        ResponseDefinitionBuilder b = aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/octet-stream")
+            .withBody(body);
+        if (contentDigest != null) {
+            b = b.withHeader("Docker-Content-Digest", contentDigest);
+        }
+        stubFor(get(urlPathEqualTo("/v2/" + repository + "/blobs/" + digest)).willReturn(b));
+    }
+}

--- a/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
+++ b/src/test/java/me/itzg/helpers/oci/InstallOciPackCommandTest.java
@@ -1,5 +1,6 @@
 package me.itzg.helpers.oci;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.tapSystemOutNormalized;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
@@ -15,15 +16,13 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import me.itzg.helpers.errors.GenericException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,7 +36,7 @@ class InstallOciPackCommandTest {
     @Test
     void pullsLayersInManifestOrderAndPrintsPaths(
         WireMockRuntimeInfo wm, @TempDir Path tempDir
-    ) throws IOException, NoSuchAlgorithmException {
+    ) throws Exception {
         final byte[] baseLayer = "shared base layer content".getBytes(StandardCharsets.UTF_8);
         final byte[] overlayLayer = "tech overlay content".getBytes(StandardCharsets.UTF_8);
         final String baseDigest = sha256(baseLayer);
@@ -53,24 +52,21 @@ class InstallOciPackCommandTest {
         stubBlob(repository, overlayDigest, overlayLayer);
 
         final Path stage = tempDir.resolve("stage");
-        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         final InstallOciPackCommand cmd = new InstallOciPackCommand();
         cmd.ref = registry + "/" + repository + ":v1";
         cmd.outputDirectory = stage;
         cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
-        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
-        cmd.setScheme("http");
+        cmd.setInsecure(true);
 
-        final Integer exit = cmd.call();
-
-        assertThat(exit).isEqualTo(ExitCode.OK);
+        final String stdout = tapSystemOutNormalized(() ->
+            assertThat(cmd.call()).isEqualTo(ExitCode.OK));
 
         final Path baseFile = stage.resolve("base.tar.gz");
         final Path overlayFile = stage.resolve("tech.tar.gz");
         assertThat(baseFile).exists().hasBinaryContent(baseLayer);
         assertThat(overlayFile).exists().hasBinaryContent(overlayLayer);
 
-        final String[] printedLines = stdout.toString(StandardCharsets.UTF_8.name()).split("\\R");
+        final String[] printedLines = nonLogLines(stdout);
         assertThat(printedLines).hasSize(2);
         assertThat(Path.of(printedLines[0])).isEqualTo(baseFile.toAbsolutePath());
         assertThat(Path.of(printedLines[1])).isEqualTo(overlayFile.toAbsolutePath());
@@ -79,7 +75,7 @@ class InstallOciPackCommandTest {
     @Test
     void writesLayerListFileForScriptedConsumers(
         WireMockRuntimeInfo wm, @TempDir Path tempDir
-    ) throws IOException, NoSuchAlgorithmException {
+    ) throws Exception {
         final byte[] baseLayer = "shared base".getBytes(StandardCharsets.UTF_8);
         final byte[] overlayLayer = "overlay".getBytes(StandardCharsets.UTF_8);
         final String baseDigest = sha256(baseLayer);
@@ -96,17 +92,16 @@ class InstallOciPackCommandTest {
 
         final Path stage = tempDir.resolve("stage");
         final Path layerList = tempDir.resolve("nested/layers.txt");
-        final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
 
         final InstallOciPackCommand cmd = new InstallOciPackCommand();
         cmd.ref = registry + "/" + repository + ":v1";
         cmd.outputDirectory = stage;
         cmd.layerListFile = layerList;
         cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
-        cmd.setOut(new PrintStream(stdout, true, StandardCharsets.UTF_8.name()));
-        cmd.setScheme("http");
+        cmd.setInsecure(true);
 
-        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+        final String stdout = tapSystemOutNormalized(() ->
+            assertThat(cmd.call()).isEqualTo(ExitCode.OK));
 
         assertThat(layerList).exists();
         assertThat(Files.readAllLines(layerList))
@@ -114,13 +109,14 @@ class InstallOciPackCommandTest {
                 stage.resolve("base.tar.gz").toAbsolutePath().toString(),
                 stage.resolve("tech.tar.gz").toAbsolutePath().toString()
             );
-        assertThat(stdout.toString(StandardCharsets.UTF_8.name())).isEmpty();
+        // With --layer-list-file set, stdout carries only logger output, no layer paths
+        assertThat(nonLogLines(stdout)).isEmpty();
     }
 
     @Test
     void skipsRedownloadWhenLayerAlreadyOnDisk(
         WireMockRuntimeInfo wm, @TempDir Path tempDir
-    ) throws IOException, NoSuchAlgorithmException {
+    ) throws Exception {
         final byte[] baseLayer = "already cached locally".getBytes(StandardCharsets.UTF_8);
         final String baseDigest = sha256(baseLayer);
 
@@ -140,10 +136,10 @@ class InstallOciPackCommandTest {
         cmd.ref = registry + "/" + repository + ":v1";
         cmd.outputDirectory = stage;
         cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
-        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
-        cmd.setScheme("http");
+        cmd.setInsecure(true);
 
-        assertThat(cmd.call()).isEqualTo(ExitCode.OK);
+        tapSystemOutNormalized(() ->
+            assertThat(cmd.call()).isEqualTo(ExitCode.OK));
 
         verify(0, com.github.tomakehurst.wiremock.client.WireMock
             .getRequestedFor(urlPathEqualTo("/v2/" + repository + "/blobs/" + baseDigest)));
@@ -173,12 +169,18 @@ class InstallOciPackCommandTest {
         cmd.ref = registry + "/" + repository + ":v1";
         cmd.outputDirectory = stage;
         cmd.filenameStrategy = InstallOciPackCommand.FilenameStrategy.title;
-        cmd.setOut(new PrintStream(new ByteArrayOutputStream()));
-        cmd.setScheme("http");
+        cmd.setInsecure(true);
 
         assertThatThrownBy(cmd::call)
             .isInstanceOf(GenericException.class)
             .hasMessageContaining("Digest mismatch");
+    }
+
+    // Logback in tests writes to stdout, so strip those lines when asserting on command output
+    private static String[] nonLogLines(String stdout) {
+        return Arrays.stream(stdout.split("\n"))
+            .filter(line -> !line.isEmpty() && !line.startsWith("[mc-image-helper]"))
+            .toArray(String[]::new);
     }
 
     private static String sha256(byte[] bytes) throws NoSuchAlgorithmException {


### PR DESCRIPTION
Adds an `install-oci-pack` subcommand that pulls OCI artifacts from any distribution-spec registry and writes layer blobs to disk in manifest order, for the `GENERIC_PACK[S]` handler in docker-minecraft-server.

Alternative implementation to #767, using the [`land.oras:oras-java-sdk`](https://github.com/oras-project/oras-java) instead of a hand-rolled client.

The SDK uses `java.net.http.HttpClient` (the JDK built-in) and has no HC5 dependency, so this change adds no new `org.apache.hc.*` imports. It targets Java 17 bytecode, so the toolchain bumps from 11 to 17. About 150 fewer LOC than #767, since the SDK handles manifest parsing, bearer auth, redirects, and digest verification.

The command surface (`--ref`, `--output-directory`, `--auth-file`, `--filename-strategy`, `--layer-list-file`) and content-addressed caching behaviour match #767.

For itzg/docker-minecraft-server#4038.