### PR TITLE
Add has-feature command to check subcommand availability and options

### DIFF
--- a/src/main/java/me/itzg/helpers/McImageHelper.java
+++ b/src/main/java/me/itzg/helpers/McImageHelper.java
@@ -38,6 +38,7 @@ import me.itzg.helpers.properties.SetPropertiesCommand;
 import me.itzg.helpers.purpur.InstallPurpurCommand;
 import me.itzg.helpers.quilt.InstallQuiltCommand;
 import me.itzg.helpers.singles.Asciify;
+import me.itzg.helpers.singles.HasFeatureCommand;
 import me.itzg.helpers.singles.HashCommand;
 import me.itzg.helpers.singles.NetworkInterfacesCommand;
 import me.itzg.helpers.singles.TestLoggingCommand;
@@ -72,6 +73,7 @@ import picocli.CommandLine.Spec;
         GetCommand.class,
         GithubCommands.class,
         HashCommand.class,
+        HasFeatureCommand.class,
         IniPathCommand.class,
         InstallCurseForgeCommand.class,
         InstallFabricLoaderCommand.class,

--- a/src/main/java/me/itzg/helpers/singles/HasFeatureCommand.java
+++ b/src/main/java/me/itzg/helpers/singles/HasFeatureCommand.java
@@ -1,0 +1,49 @@
+package me.itzg.helpers.singles;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+@Command(name = "has-feature",
+    description = "Check if a subcommand is available and optionally if it has specific options (arguments)")
+public class HasFeatureCommand implements Callable<Integer> {
+
+    @Spec
+    CommandSpec spec;
+
+    @Parameters(index = "0", description = "The subcommand name to check for availability")
+    String subcommand;
+
+    @Parameters(index = "1", arity = "0..*", description = "Optional option names to check within the subcommand (e.g., 'help' for --help or -h)")
+    String[] arguments;
+
+    @Override
+    public Integer call() throws Exception {
+        Map<String, CommandLine> subcommands = spec.parent().subcommands();
+
+        if (!subcommands.containsKey(subcommand)) {
+            return ExitCode.SOFTWARE; // Subcommand not found
+        }
+
+        if (arguments != null && arguments.length > 0) {
+            CommandSpec subSpec = subcommands.get(subcommand).getCommandSpec();
+            for (String argument : arguments) {
+                boolean hasOption = subSpec.options().stream()
+                    .anyMatch(opt -> Arrays.stream(opt.names())
+                        .anyMatch(name -> name.equals("--" + argument) ||
+                                         (argument.length() == 1 && name.equals("-" + argument))));
+                if (!hasOption) {
+                    return ExitCode.SOFTWARE; // Option not found in subcommand
+                }
+            }
+        }
+
+        return ExitCode.OK; // Subcommand (and options, if specified) are available
+    }
+}

--- a/src/test/java/me/itzg/helpers/singles/HasFeatureCommandTest.java
+++ b/src/test/java/me/itzg/helpers/singles/HasFeatureCommandTest.java
@@ -1,0 +1,51 @@
+package me.itzg.helpers.singles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class HasFeatureCommandTest {
+
+  @Test
+  void subcommandExists() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "hash");
+    assertThat(exitCode).isEqualTo(0);
+  }
+
+  @Test
+  void subcommandDoesNotExist() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "nonexistent");
+    assertThat(exitCode).isEqualTo(1);
+  }
+
+  @Test
+  void subcommandExistsWithExistingOption() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "install-fabric-loader", "help");
+    assertThat(exitCode).isEqualTo(0);
+  }
+
+  @Test
+  void subcommandExistsWithNonExistingOption() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "install-fabric-loader", "nonexistent");
+    assertThat(exitCode).isEqualTo(1);
+  }
+
+  @Test
+  void subcommandExistsWithMultipleExistingOptions() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "install-fabric-loader", "help", "loader-version");
+    assertThat(exitCode).isEqualTo(0);
+  }
+
+  @Test
+  void subcommandExistsWithMultipleOptionsOneMissing() {
+    final int exitCode = new CommandLine(new me.itzg.helpers.McImageHelper())
+        .execute("has-feature", "install-fabric-loader", "help", "nonexistent");
+    assertThat(exitCode).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
This will be used to support the matrix java version builds of itzg/minecraft-server. The Java 8 - 16 images will use the "java8" branch releases of helper. As such, the image scripts need to gracefully fail if a feature isn't available that is only supported on Java 17+.