### PR TITLE
neoforge: fix version extraction from version.json

### DIFF
--- a/src/main/java/me/itzg/helpers/forge/ProvidedInstallerResolver.java
+++ b/src/main/java/me/itzg/helpers/forge/ProvidedInstallerResolver.java
@@ -121,12 +121,13 @@ public class ProvidedInstallerResolver implements InstallerResolver {
             if (idParts[1].equals(INSTALLER_ID_FORGE)) {
                 return new VersionPair(minecraftVersion, idParts[2]);
             }
-            if (idParts[0].equals(INSTALLER_ID_NEOFORGE)) {
-                return new VersionPair(minecraftVersion, idParts[1]);
-            }
             if (idParts[0].equals(INSTALLER_ID_CLEANROOM)) {
                 return new VersionPair(minecraftVersion, String.join("-", idParts[1], idParts[2]))
                     .setVariantOverride(INSTALLER_ID_CLEANROOM);
+            }
+        } else if (idParts.length >= 2) {
+            if (idParts[0].equals(INSTALLER_ID_NEOFORGE)) {
+                return new VersionPair(minecraftVersion, idParts[1]);
             }
         }
 


### PR DESCRIPTION
NeoForge installer's version is formatted like `neoforge-21.1.231`, i.e. only two parts. The current logic thus always fails to parse this, and throws an `Unexpected format of id from Forge installer's version.json` exception as long as NeoForge is being installed from a local installer. I mean, *c'mon*, someone got to have discovered this in the past 3 months...