### PR TITLE
cf: support modpacks using NeoForge 26.+ beta versions

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -985,6 +985,7 @@ public class CurseForgeInstaller {
 
         // id could be values like
         // neoforge-1.20.1-47.1.99
+        // neoforge-26.1.2.68-beta
         final String[] parts = id.split("-", 3);
         if (parts.length < 2) {
             throw new GenericException("Unknown modloader ID: " + id);
@@ -1007,7 +1008,7 @@ public class CurseForgeInstaller {
                     break;
 
                 case "neoforge":
-                    prepareNeoForge(sharedFetch, minecraftVersion, loaderVersion);
+                    prepareNeoForge(sharedFetch, minecraftVersion, id);
                     break;
 
                 case "fabric":
@@ -1040,10 +1041,12 @@ public class CurseForgeInstaller {
             .install(outputDir, resultsFile, forceReinstallModloader, "Forge");
     }
 
-    private void prepareNeoForge(SharedFetch sharedFetch, String minecraftVersion, String loaderVersion) {
+    private void prepareNeoForge(SharedFetch sharedFetch, String minecraftVersion, String loaderId) {
         new ForgeLikeInstaller(
-            new NeoForgeInstallerResolver(sharedFetch,
-                minecraftVersion, loaderVersion
+            NeoForgeInstallerResolver.givenLoaderId(
+                sharedFetch,
+                minecraftVersion,
+                loaderId
             )
         )
             .install(outputDir, resultsFile, forceReinstallModloader, "NeoForge");

--- a/src/main/java/me/itzg/helpers/forge/IdResolver.java
+++ b/src/main/java/me/itzg/helpers/forge/IdResolver.java
@@ -1,0 +1,28 @@
+package me.itzg.helpers.forge;
+
+import me.itzg.helpers.errors.GenericException;
+
+public class IdResolver {
+
+    static VersionPair buildVersionFromId(String id, String minecraftVersion) {
+        final String[] idParts = id.split("-");
+        if (idParts.length >= 3) {
+            if (idParts[1].equals(ProvidedInstallerResolver.INSTALLER_ID_FORGE)) {
+                return new VersionPair(minecraftVersion, idParts[2]);
+            }
+            if (idParts[0].equals(ProvidedInstallerResolver.INSTALLER_ID_NEOFORGE)) {
+                return new VersionPair(minecraftVersion, String.join("-", idParts[1], idParts[2]));
+            }
+            if (idParts[0].equals(ProvidedInstallerResolver.INSTALLER_ID_CLEANROOM)) {
+                return new VersionPair(minecraftVersion, String.join("-", idParts[1], idParts[2]))
+                    .setVariantOverride(ProvidedInstallerResolver.INSTALLER_ID_CLEANROOM);
+            }
+        } else if (idParts.length >= 2) {
+            if (idParts[0].equals(ProvidedInstallerResolver.INSTALLER_ID_NEOFORGE)) {
+                return new VersionPair(minecraftVersion, idParts[1]);
+            }
+        }
+
+        throw new GenericException("Unexpected format of id from Forge installer's version.json: " + id);
+    }
+}

--- a/src/main/java/me/itzg/helpers/forge/NeoForgeInstallerResolver.java
+++ b/src/main/java/me/itzg/helpers/forge/NeoForgeInstallerResolver.java
@@ -18,6 +18,7 @@ import me.itzg.helpers.mvn.MavenRepoApi;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.NonNull;
 
 @Slf4j
@@ -33,7 +34,32 @@ public class NeoForgeInstallerResolver implements InstallerResolver {
     private final String requestedMinecraftVersion;
     private final String requestedNeoForgeVersion;
 
-    public NeoForgeInstallerResolver(SharedFetch sharedFetch,
+    public static NeoForgeInstallerResolver givenLoaderVersion(SharedFetch sharedFetch,
+        String requestedMinecraftVersion,
+        String requestedNeoForgeVersion
+    ) {
+        return new NeoForgeInstallerResolver(sharedFetch, requestedMinecraftVersion, requestedNeoForgeVersion);
+    }
+
+    public static NeoForgeInstallerResolver givenLoaderId(SharedFetch sharedFetch,
+        String requestedMinecraftVersion,
+        String loaderId
+    ) {
+        final VersionPair version = IdResolver.buildVersionFromId(loaderId, requestedMinecraftVersion);
+        return new NeoForgeInstallerResolver(sharedFetch, version.minecraft, version.forge);
+    }
+
+    @VisibleForTesting
+    static NeoForgeInstallerResolver givenLoaderId(SharedFetch sharedFetch,
+        String requestedMinecraftVersion,
+        String loaderId,
+        String neoforgeMavenRepoUrl
+    ) {
+        final VersionPair version = IdResolver.buildVersionFromId(loaderId, requestedMinecraftVersion);
+        return new NeoForgeInstallerResolver(sharedFetch, version.minecraft, version.forge, neoforgeMavenRepoUrl);
+    }
+
+    protected NeoForgeInstallerResolver(SharedFetch sharedFetch,
         @NotNull
         String requestedMinecraftVersion,
         @Nullable
@@ -42,7 +68,7 @@ public class NeoForgeInstallerResolver implements InstallerResolver {
         this(sharedFetch, requestedMinecraftVersion, requestedNeoForgeVersion, DEFAULT_MVN_URL);
     }
 
-    NeoForgeInstallerResolver(SharedFetch sharedFetch,
+    protected NeoForgeInstallerResolver(SharedFetch sharedFetch,
         @NotNull
         String requestedMinecraftVersion,
         @Nullable

--- a/src/main/java/me/itzg/helpers/forge/ProvidedInstallerResolver.java
+++ b/src/main/java/me/itzg/helpers/forge/ProvidedInstallerResolver.java
@@ -116,24 +116,7 @@ public class ProvidedInstallerResolver implements InstallerResolver {
         }
         final String minecraftVersion = inheritsFromNode.asText();
 
-        final String[] idParts = id.split("-");
-        if (idParts.length >= 3) {
-            if (idParts[1].equals(INSTALLER_ID_FORGE)) {
-                return new VersionPair(minecraftVersion, idParts[2]);
-            }
-            if (idParts[0].equals(INSTALLER_ID_NEOFORGE)) {
-                return new VersionPair(minecraftVersion, String.join("-", idParts[1], idParts[2]));
-            }
-            if (idParts[0].equals(INSTALLER_ID_CLEANROOM)) {
-                return new VersionPair(minecraftVersion, String.join("-", idParts[1], idParts[2]))
-                    .setVariantOverride(INSTALLER_ID_CLEANROOM);
-            }
-        } else if (idParts.length >= 2) {
-            if (idParts[0].equals(INSTALLER_ID_NEOFORGE)) {
-                return new VersionPair(minecraftVersion, idParts[1]);
-            }
-        }
-
-        throw new GenericException("Unexpected format of id from Forge installer's version.json: " + id);
+        return IdResolver.buildVersionFromId(id, minecraftVersion);
     }
+
 }

--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthPackInstaller.java
@@ -21,8 +21,8 @@ import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.fabric.FabricLauncherInstaller;
 import me.itzg.helpers.files.AntPathMatcher;
 import me.itzg.helpers.files.IoStreams;
-import me.itzg.helpers.forge.ForgeLikeInstaller;
 import me.itzg.helpers.forge.ForgeInstallerResolver;
+import me.itzg.helpers.forge.ForgeLikeInstaller;
 import me.itzg.helpers.forge.ForgeUrlArgs;
 import me.itzg.helpers.forge.NeoForgeInstallerResolver;
 import me.itzg.helpers.http.SharedFetch;
@@ -230,6 +230,13 @@ public class ModrinthPackInstaller {
         for (final Entry<DependencyId, ModloaderPreparer> entry : modloaderPreparers.entrySet()) {
             final String version = dependencies.get(entry.getKey());
             if (version != null) {
+                /*
+                NOTE: neoforge 26.+ and beta versions are formatted correctly as
+                    "dependencies": {
+                        "minecraft": "26.1.2",
+                        "neoforge": "26.1.2.59-beta"
+                    }
+                 */
                 entry.getValue().prepare(sharedFetch, minecraftVersion, version);
                 return;
             }
@@ -284,7 +291,7 @@ public class ModrinthPackInstaller {
 
     private void prepareNeoForge(SharedFetch sharedFetch, String minecraftVersion, String version) {
         new ForgeLikeInstaller(
-            new NeoForgeInstallerResolver(sharedFetch, minecraftVersion, version)
+            NeoForgeInstallerResolver.givenLoaderVersion(sharedFetch, minecraftVersion, version)
         )
             .install(
                 this.outputDirectory,

--- a/src/test/java/me/itzg/helpers/forge/NeoForgeInstallerResolverTest.java
+++ b/src/test/java/me/itzg/helpers/forge/NeoForgeInstallerResolverTest.java
@@ -41,6 +41,15 @@ class NeoForgeInstallerResolverTest {
         );
     }
 
+    public static Stream<Arguments> resolve_loaderId_args() {
+        // minecraftVersion, loaderId, expectedMinecraftVersion, expectedNeoforgeVersion
+        // needs to be in resources/__files/forge/neoforged-neoforge-maven-metadata.xml
+        return Stream.of(
+            arguments("26.1.2", "neoforge-26.1.2.7-beta", "26.1.2", "26.1.2.7-beta"),
+            arguments("latest", "neoforge-20.2.88", "1.20.2", "20.2.88")
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("resolve_args")
     void resolve(String minecraftVersion, String neoforgeVersion,
@@ -75,6 +84,39 @@ class NeoForgeInstallerResolverTest {
                 assertThat(versionPair.forge).isEqualTo(expectedNeoforgeVersion);
             }
 
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolve_loaderId_args")
+    void resolveLoaderId(String minecraftVersion, String loaderId,
+        String expectedMinecraftVersion, String expectedNeoforgeVersion,
+        WireMockRuntimeInfo wmInfo
+    ) {
+        try (SharedFetch sharedFetch = Fetch.sharedFetch("install-neoforge", Options.builder().build())) {
+            final VersionPair requestedVersion = IdResolver.buildVersionFromId(loaderId, minecraftVersion);
+            final NeoForgeInstallerResolver resolver =
+                NeoForgeInstallerResolver.givenLoaderId(sharedFetch,
+                    requestedVersion.minecraft, loaderId,
+                    wmInfo.getHttpBaseUrl()
+                );
+
+            stubFor(get("/net/neoforged/neoforge/maven-metadata.xml")
+                .willReturn(aResponse()
+                    .withBodyFile("forge/neoforged-neoforge-maven-metadata.xml")
+                )
+            );
+            stubFor(get("/net/neoforged/forge/maven-metadata.xml")
+                .willReturn(aResponse()
+                    .withBodyFile("forge/neoforged-forge-maven-metadata.xml")
+                )
+            );
+
+            final VersionPair versionPair = resolver.resolve(null);
+
+            assertThat(versionPair).isNotNull();
+            assertThat(versionPair.minecraft).isEqualTo(expectedMinecraftVersion);
+            assertThat(versionPair.forge).isEqualTo(expectedNeoforgeVersion);
         }
     }
 


### PR DESCRIPTION
For https://github.com/itzg/docker-minecraft-server/issues/4091

Modrinth modpacks are fine since they convey the loader version and not an ID, such as

```json
    "dependencies": {
        "minecraft": "26.1.2",
        "neoforge": "26.1.2.59-beta"
    }
```