### PR TITLE
ServerLibraryCleaner: Add Forge support for server library cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ loader instances
 
 ```
 Usage: mc-image-helper install-forge [-h] [--force-reinstall]
+                                     [--clean-libraries]
                                      [--minecraft-version=VERSION]
                                      [--output-directory=DIR]
                                      [--results-file=FILE]
@@ -556,6 +557,8 @@ Usage: mc-image-helper install-forge [-h] [--force-reinstall]
                                      DURATION]] [[--forge-promotions-url=URL]
                                      [--forge-maven-repo-url=URL]]
 Downloads and installs a requested version of Forge
+      --clean-libraries   Remove installed libraries not required by the Forge
+                            shim
       --connection-pool-max-idle-timeout=DURATION
 
       --connection-pool-pending-acquire-timeout=DURATION

--- a/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
@@ -22,6 +22,8 @@ import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.files.Manifests;
 import me.itzg.helpers.files.ResultsFileWriter;
 import me.itzg.helpers.json.ObjectMappers;
+import me.itzg.helpers.libraries.LibraryCleaner;
+import me.itzg.helpers.libraries.LibraryListPaths;
 import org.jetbrains.annotations.Nullable;
 
 @Slf4j
@@ -42,6 +44,16 @@ public class ForgeLikeInstaller {
         @Nullable Path resultsFile,
         boolean forceReinstall,
         String variant
+    ) {
+        install(outputDir, resultsFile, forceReinstall, variant, false);
+    }
+
+    public void install(
+        @NonNull Path outputDir,
+        @Nullable Path resultsFile,
+        boolean forceReinstall,
+        String variant,
+        boolean cleanLibraries
     ) {
         final String manifestId = variant.toLowerCase();
         final ForgeManifest prevManifest;

--- a/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
@@ -134,17 +134,20 @@ public class ForgeLikeInstaller {
         }
 
         if (cleanLibraries) {
-            final Path shimJar = findShimJar(outputDir, Optional.ofNullable(resolved.variantOverride).orElse(variant), resolved.minecraft, resolved.forge);
 
             if (new ComparableVersion(resolved.minecraft).compareTo(MIN_SHIM_JAR_MC_VERSION) < 0) {
                 log.warn("Forge library cleanup requires Minecraft {} or newer", MIN_SHIM_JAR_MC_VERSION);
                 return;
             }
-            if (shimJar == null) {
+
+            final Path shimJar = outputDir.resolve(String.format("%s-%s-%s-shim.jar", variant.toLowerCase(), resolved.minecraft, resolved.forge));
+
+            if (!Files.exists(shimJar)) {
                 log.warn("Unable to locate {} shim jar for library cleanup", variant);
-            } else {
-                new LibraryCleaner(shimJar, LibraryListPaths.FORGE).cleanLibraries();
+                return;
             }
+
+            new LibraryCleaner(shimJar, LibraryListPaths.FORGE).cleanLibraries();
         }
     }
 
@@ -291,11 +294,6 @@ public class ForgeLikeInstaller {
         (v,m, f) -> String.format("%s-%s.jar", v, f)
     );
 
-    private static Path findShimJar(Path outputDir, String variant, String minecraftVersion, String forgeVersion) {
-        final Path path = outputDir.resolve(String.format("%s-%s-%s-shim.jar",
-            variant.toLowerCase(), minecraftVersion, forgeVersion));
-        return Files.exists(path) ? path : null;
-    }
 
     private static Path findEntryJar(Path outputDir, String variant, String minecraftVersion, String forgeVersion) {
         for (final ServerJarNameBuilder builder : serverJarNameBuilders) {

--- a/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
@@ -129,6 +129,16 @@ public class ForgeLikeInstaller {
                 throw new RuntimeException("Failed to populate results file", e);
             }
         }
+
+        if (cleanLibraries) {
+            final Path shimJar = findShimJar(outputDir, Optional.ofNullable(resolved.variantOverride).orElse(variant), resolved.minecraft, resolved.forge);
+
+            if (shimJar == null) {
+                log.warn("Unable to locate {} shim jar for library cleanup", variant);
+            } else {
+                new LibraryCleaner(shimJar, LibraryListPaths.FORGE).cleanLibraries();
+            }
+        }
     }
 
     private boolean serverEntryExists(@NonNull Path outputDir, String serverEntry) {

--- a/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
@@ -274,6 +274,12 @@ public class ForgeLikeInstaller {
         (v,m, f) -> String.format("%s-%s.jar", v, f)
     );
 
+    private static Path findShimJar(Path outputDir, String variant, String minecraftVersion, String forgeVersion) {
+        final Path path = outputDir.resolve(String.format("%s-%s-%s-shim.jar",
+            variant.toLowerCase(), minecraftVersion, forgeVersion));
+        return Files.exists(path) ? path : null;
+    }
+
     private static Path findEntryJar(Path outputDir, String variant, String minecraftVersion, String forgeVersion) {
         for (final ServerJarNameBuilder builder : serverJarNameBuilders) {
             final Path path = outputDir.resolve(builder.build(variant.toLowerCase(), minecraftVersion, forgeVersion));

--- a/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
+++ b/src/main/java/me/itzg/helpers/forge/ForgeLikeInstaller.java
@@ -24,6 +24,8 @@ import me.itzg.helpers.files.ResultsFileWriter;
 import me.itzg.helpers.json.ObjectMappers;
 import me.itzg.helpers.libraries.LibraryCleaner;
 import me.itzg.helpers.libraries.LibraryListPaths;
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.Nullable;
 
 @Slf4j
@@ -32,6 +34,7 @@ public class ForgeLikeInstaller {
     private static final Pattern RESULT_INFO = Pattern.compile(
         "Exec:\\s+(?<exec>.+)"
             + "|The server installed successfully, you should now be able to run the file (?<universalJar>.+)");
+    private static final ComparableVersion MIN_SHIM_JAR_MC_VERSION = new ComparableVersion("1.20.3");
 
     private final InstallerResolver installerResolver;
 
@@ -133,6 +136,10 @@ public class ForgeLikeInstaller {
         if (cleanLibraries) {
             final Path shimJar = findShimJar(outputDir, Optional.ofNullable(resolved.variantOverride).orElse(variant), resolved.minecraft, resolved.forge);
 
+            if (new ComparableVersion(resolved.minecraft).compareTo(MIN_SHIM_JAR_MC_VERSION) < 0) {
+                log.warn("Forge library cleanup requires Minecraft {} or newer", MIN_SHIM_JAR_MC_VERSION);
+                return;
+            }
             if (shimJar == null) {
                 log.warn("Unable to locate {} shim jar for library cleanup", variant);
             } else {

--- a/src/main/java/me/itzg/helpers/forge/InstallForgeCommand.java
+++ b/src/main/java/me/itzg/helpers/forge/InstallForgeCommand.java
@@ -87,6 +87,9 @@ public class InstallForgeCommand implements Callable<Integer> {
     @Option(names = "--force-reinstall")
     boolean forceReinstall;
 
+    @Option(names = "--clean-libraries", defaultValue = "false", description = "Remove installed libraries not required by the Forge shim")
+    boolean cleanLibraries;
+
     @ArgGroup(exclusive = false)
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
@@ -107,7 +110,7 @@ public class InstallForgeCommand implements Callable<Integer> {
 
             );
 
-            installer.install(outputDirectory, resultsFile, forceReinstall, "Forge");
+            installer.install(outputDirectory, resultsFile, forceReinstall, "Forge", cleanLibraries);
         }
 
         return ExitCode.OK;

--- a/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryCleaner.java
@@ -130,7 +130,7 @@ public class LibraryCleaner {
                 libs = br.lines()
                         .map(String::trim)
                         .map(s -> s.split("\\s+"))
-                        .filter(parts -> parts.length > 1)
+                        .filter(parts -> parts.length >= 3)
                         .map(parts -> parts[2])
                         .collect(Collectors.toList());
 

--- a/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
+++ b/src/main/java/me/itzg/helpers/libraries/LibraryListPaths.java
@@ -10,5 +10,5 @@ public enum LibraryListPaths {
     PURPUR("META-INF/libraries.list"),
     FORGE("bootstrap-shim.list");
 
-    private String path;
+    private final String path;
 }


### PR DESCRIPTION
When forge installs, it creates a "*-shim.jar" file, this jar is the entrypoint for the server, and contains the `bootstrap-shim.list`.

The `bootstrap-shim.list` is then read like other Jar types, parsed, and the diff between the installed and required libs are deleted.

## Backwards Compatability
This way of reading libraries is only compatible and tested with Forge 49.0.2 installer for Minecraft 1.20.3 or newer.

I believe @itzg in a previous comment you mentioned preference for a best-effort coverage, and not to be concerned with full backwards compatibility, however if you'd prefer support for prior versions, i'm happy to look at it

