### PR TITLE
interpolate: guard against large files

### DIFF
--- a/src/main/java/me/itzg/helpers/sync/InterpolateCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/InterpolateCommand.java
@@ -6,19 +6,27 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.Setter;
 import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.env.EnvironmentVariablesProvider;
 import me.itzg.helpers.env.InterpolationException;
 import me.itzg.helpers.env.Interpolator;
 import me.itzg.helpers.env.StandardEnvironmentVariablesProvider;
 import me.itzg.helpers.errors.GenericException;
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.VisibleForTesting;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "interpolate",
 description = "Interpolates existing files in one or more directories")
 @Slf4j
 public class InterpolateCommand implements Callable<Integer> {
+
+    public static final long FILE_SIZE_LIMIT = 100 * FileUtils.ONE_MB;
+
     @CommandLine.Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this usage and exit")
     @ToString.Exclude
     boolean showHelp;
@@ -29,9 +37,13 @@ public class InterpolateCommand implements Callable<Integer> {
     @CommandLine.Parameters(paramLabel = "DIRECTORY")
     List<Path> directories;
 
+    @VisibleForTesting
+    @Setter(AccessLevel.PACKAGE)
+    EnvironmentVariablesProvider environmentVariablesProvider = new StandardEnvironmentVariablesProvider();
+
     @Override
     public Integer call() throws Exception {
-        final Interpolator interpolator = new Interpolator(new StandardEnvironmentVariablesProvider(), replaceEnv.prefix);
+        final Interpolator interpolator = new Interpolator(environmentVariablesProvider, replaceEnv.prefix);
 
         for (Path directory : directories) {
             if (!Files.isDirectory(directory)) {
@@ -59,6 +71,15 @@ public class InterpolateCommand implements Callable<Integer> {
 
     @SneakyThrows
     private void processFile(Path path, Interpolator interpolator) {
+        final long size = Files.size(path);
+        if (size > FILE_SIZE_LIMIT) {
+            log.warn("Skipping interpolating '{}' because it is too large ({} > {})", path,
+                FileUtils.byteCountToDisplaySize(size),
+                FileUtils.byteCountToDisplaySize(FILE_SIZE_LIMIT)
+            );
+            return;
+        }
+
         log.debug("Interpolating file={}", path);
         final byte[] original = Files.readAllBytes(path);
 

--- a/src/test/java/me/itzg/helpers/sync/InterpolateCommandTest.java
+++ b/src/test/java/me/itzg/helpers/sync/InterpolateCommandTest.java
@@ -1,0 +1,46 @@
+package me.itzg.helpers.sync;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import me.itzg.helpers.env.MappedEnvVarProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+import picocli.CommandLine.ExitCode;
+
+class InterpolateCommandTest {
+
+    @Test
+    void skipsLargeFiles(@TempDir Path tempDir) throws Exception {
+        final long size = InterpolateCommand.FILE_SIZE_LIMIT + 1;
+
+        final Path path = tempDir.resolve("largeFile.txt");
+        try {
+            Files.createFile(path);
+            Files.write(path, new byte[(int) size]);
+        } catch (Exception e) {
+            fail("Failed to create large file", e);
+        }
+
+        final String out = SystemLambda.tapSystemErrAndOut(() -> {
+            final int result = new CommandLine(
+                new InterpolateCommand()
+                    .setEnvironmentVariablesProvider(MappedEnvVarProvider.of(
+                        "CFG_FIELD", "not used"
+                    ))
+            )
+                .execute(
+                    "--replace-env-file-suffixes", "txt",
+                    tempDir.toString()
+                );
+
+            assertThat(result).isEqualTo(ExitCode.OK);
+        });
+
+        assertThat(out).containsIgnoringCase("skipping");
+    }
+}


### PR DESCRIPTION
Fixes #790

Files over 100MB are skipped with a logged warning.