### PR TITLE
cf: clearer exception when a mod file's info is not found

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
@@ -239,8 +239,11 @@ public class CurseForgeApiClient implements AutoCloseable {
                     final FailedRequestException fre = (FailedRequestException) e;
                     if (fre.getStatusCode() == 400) {
                         if (isNotFoundResponse(fre.getBody())) {
-                            return new InvalidParameterException("Requested file not found for modpack", e);
+                            return new GenericException(String.format("Requested file ID %d for project %d not found", fileID, projectID), e);
                         }
+                    }
+                    else if (fre.getStatusCode() == 404) {
+                        return new GenericException(String.format("Requested file ID %d for project %d not found", fileID, projectID), e);
                     }
                     return e;
                 })


### PR DESCRIPTION
Helps clarify this type of error a little bit

```
[mc-image-helper] 15:18:41.230 ERROR : 'install-curseforge' command failed. Version is 1.51.3-java8: FailedRequestException: HTTP request of https://api.curseforge.com/v1/mods/580181/files/6090721 failed with 404 Not Found: Fetching object content
```

[Discussed in Discord](https://discord.com/channels/660567679458869252/660569755320844308/1522260334491205673)