### PR TITLE
Switching to http/2 by default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,10 @@ dependencies {
 
   implementation(platform('com.fasterxml.jackson:jackson-bom:2.21.3'))
   // 1.4.+ requires Java 11 and we are stuck on 8
-  implementation(platform('ch.qos.logback:logback-parent:[1.3.5,1.4)'))
+  implementation(platform('ch.qos.logback:logback-parent:1.5.25'))
+  // reactor-bom lags netty just a bit, so make sure it's the one preferred since we use reactor directly
+  implementation enforcedPlatform('io.projectreactor:reactor-bom:2025.0.6')
+  implementation platform('io.netty:netty-bom:4.2.16.Final')
 
   implementation 'ch.qos.logback:logback-core'
   implementation 'ch.qos.logback:logback-classic'
@@ -103,15 +106,17 @@ dependencies {
   implementation 'com.kjetland:mbknor-jackson-jsonschema_2.13:1.0.39'
   implementation 'com.jayway.jsonpath:json-path:2.10.0'
   implementation 'org.apache.httpcomponents.client5:httpclient5:5.6.2'
-  implementation ('io.projectreactor.netty:reactor-netty-http:1.3.6') {
+  implementation ('io.projectreactor.netty:reactor-netty-http') {
     // http3/quic is not functional on Alpine due to absence of glibc/ld-linux
     // Error loading shared library ld-linux-x86-64.so.2:
+
     //    No such file or directory (needed by /tmp/libnetty_quiche42_linux_x86_641323735684306068308.so)
     // Also needs to handle
     // java.lang.NoClassDefFoundError: io/netty/handler/codec/quic/Quic
     //	at reactor.netty.http.internal.Http3.isHttp3Available(Http3.java:35)
     exclude group: 'io.netty', module: 'netty-codec-native-quic'
   }
+  runtimeOnly 'io.netty:netty-tcnative-boringssl-static'
   implementation 'org.apache.maven:maven-artifact:3.9.16'
   implementation 'commons-codec:commons-codec:1.22.0'
   implementation 'org.jetbrains:annotations:26.1.0'
@@ -124,7 +129,10 @@ dependencies {
   testImplementation 'org.assertj:assertj-core:3.27.7'
   // https://github.com/webcompere/model-assert
   // for json assertions
-  testImplementation 'uk.org.webcompere:model-assert:1.1.0'
+  testImplementation ('uk.org.webcompere:model-assert:1.1.0') {
+    // it prefers older version
+    exclude group: 'ch.qos.logback', module: 'logback-core'
+  }
 
   // https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom
   // stuck < 5.12.0 due to Java 8

--- a/src/main/java/me/itzg/helpers/http/SharedFetch.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetch.java
@@ -94,7 +94,13 @@ public class SharedFetch implements AutoCloseable {
             log.debug("Using HTTP/2");
             return c
                 // https://projectreactor.io/docs/netty/release/reference/http-client.html#HTTP2
-                .protocol(HttpProtocol.HTTP11, HttpProtocol.H2)
+                .protocol(HttpProtocol.H2, HttpProtocol.HTTP11)
+                .http2Settings(settings ->
+                    // Reference https://projectreactor.io/docs/netty/release/reference/index.html#http2-settings
+                    settings
+                        .initialWindowSize(options.getHttp2InitialWindowSize())
+                        .maxFrameSize(options.getHttp2MaxFrameSize())
+                )
                 .secure(spec ->
                     // Http2 SSL supports both HTTP/2 and HTTP/1.1
                     spec.sslContext((GenericSslContextSpec<?>) Http2SslContextSpec.forClient())
@@ -157,7 +163,13 @@ public class SharedFetch implements AutoCloseable {
         private final URI filesViaUrl;
 
         @Default
-        private final boolean useHttp2 = false;
+        private final boolean useHttp2 = true;
+
+        @Default
+        private final int http2InitialWindowSize = 65535 * 16;
+
+        @Default
+        private final int http2MaxFrameSize = 65535;
 
         private final boolean wiretap;
 
@@ -168,7 +180,7 @@ public class SharedFetch implements AutoCloseable {
 
             return new Options(
                 responseTimeout, tlsHandshakeTimeout, maxIdleTimeout, pendingAcquireTimeout,
-                newHeaders, filesViaUrl, useHttp2, wiretap
+                newHeaders, filesViaUrl, useHttp2, http2InitialWindowSize, http2MaxFrameSize, wiretap
             );
         }
     }

--- a/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
+++ b/src/main/java/me/itzg/helpers/http/SharedFetchArgs.java
@@ -19,8 +19,10 @@ public class SharedFetchArgs {
 
     @Option(names = "--http-response-timeout", defaultValue = "${env:FETCH_RESPONSE_TIMEOUT:-PT30S}",
         paramLabel = "DURATION",
+        hidden = true,
         description = "The response timeout to apply to HTTP operations. Parsed from ISO-8601 format. "
             + "Default: ${DEFAULT-VALUE}"
+            + "%nEnv: FETCH_RESPONSE_TIMEOUT"
     )
     public void setResponseTimeout(Duration timeout) {
         optionsBuilder.responseTimeout(timeout);
@@ -28,35 +30,69 @@ public class SharedFetchArgs {
 
     @Option(names = "--tls-handshake-timeout", defaultValue = "${env:FETCH_TLS_HANDSHAKE_TIMEOUT:-PT30S}",
         paramLabel = "DURATION",
-        description = "Default: ${DEFAULT-VALUE}"
+        hidden = true,
+        description = "Default: ${DEFAULT-VALUE}" 
+            + "%nEnv: FETCH_TLS_HANDSHAKE_TIMEOUT"
     )
     public void setTlsHandshakeTimeout(Duration timeout) {
         optionsBuilder.tlsHandshakeTimeout(timeout);
     }
 
     @Option(names = "--connection-pool-max-idle-timeout", defaultValue = "${env:FETCH_CONNECTION_POOL_MAX_IDLE_TIMEOUT:-PT15S}",
-        paramLabel = "DURATION"
+        paramLabel = "DURATION",
+        hidden = true,
+        description = "Default: ${DEFAULT-VALUE}" 
+            + "%nEnv: FETCH_CONNECTION_POOL_MAX_IDLE_TIMEOUT"
     )
     public void setConnectionPoolMaxIdleTimeout(Duration timeout) {
         optionsBuilder.maxIdleTimeout(timeout);
     }
 
     @Option(names = "--connection-pool-pending-acquire-timeout", defaultValue = "${env:FETCH_CONNECTION_POOL_PENDING_ACQUIRE_TIMEOUT}",
-        paramLabel = "DURATION"
+        paramLabel = "DURATION",
+        hidden = true,
+        description = "Default: ${DEFAULT-VALUE}"
+            + "%nEnv: FETCH_CONNECTION_POOL_PENDING_ACQUIRE_TIMEOUT"
     )
     public void setPendingAcquireTimeout(Duration timeout) {
         optionsBuilder.pendingAcquireTimeout(timeout);
     }
 
-    @Option(names = "--use-http2", defaultValue = "${env:FETCH_USE_HTTP2:-false}",
-        description = "Whether to use HTTP/2. Default: ${DEFAULT-VALUE}"
+    @Option(names = "--use-http2", defaultValue = "${env:FETCH_USE_HTTP2:-true}",
+        description = "Whether to use HTTP/2." 
+            + "%nDefault: ${DEFAULT-VALUE}" 
+            + "%nEnv: FETCH_USE_HTTP2"
     )
     public void setUseHttp2(boolean useHttp2) {
         optionsBuilder.useHttp2(useHttp2);
     }
 
+    @Option(names = "--http2-initial-window-size", defaultValue = "${env:FETCH_HTTP2_INITIAL_WINDOW_SIZE}",
+        paramLabel = "BYTES",
+        hidden = true,
+        description = "The initial window size for HTTP/2 connections."
+            + "%nDefault: ${DEFAULT-VALUE}"
+            + "%nEnv: FETCH_HTTP2_INITIAL_WINDOW_SIZE"
+    )
+    public void setHttp2InitialWindowSize(int size) {
+        optionsBuilder.http2InitialWindowSize(size);
+    }
+
+    @Option(names = "--http2-max-frame-size", defaultValue = "${env:FETCH_HTTP2_MAX_FRAME_SIZE}",
+        paramLabel = "BYTES",
+        hidden = true,
+        description = "The maximum frame size for HTTP/2 connections."
+            + "%nDefault: ${DEFAULT-VALUE}"
+            + "%nEnv: FETCH_HTTP2_MAX_FRAME_SIZE"
+    )
+    public void setHttp2MaxFrameSize(int size) {
+        optionsBuilder.http2MaxFrameSize(size);
+    }
+
     @Option(names = "--wiretap", defaultValue = "${env:FETCH_WIRETAP:-false}",
-        description = "Whether to enable Reactor Netty wiretap logging. Default: ${DEFAULT-VALUE}"
+        description = "Whether to enable Reactor Netty wiretap logging. Make sure to set logging level to trace."
+            + "%nDefault: ${DEFAULT-VALUE}" 
+            + "%nEnv: FETCH_WIRETAP"
     )
     public void setWiretap(boolean wiretap) {
         optionsBuilder.wiretap(wiretap);

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <conversionRule conversionWord="customHighlight" converterClass="me.itzg.helpers.logger.CustomHighlight" />
+    <conversionRule conversionWord="customHighlight" class="me.itzg.helpers.logger.CustomHighlight" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>


### PR DESCRIPTION
Hoping it fixes [an issue discussed in Discord](https://discord.com/channels/660567679458869252/660569641550217327/1525145411474423951) where the error is

```
[mc-image-helper] 15:41:32.180 DEBUG : Using HTTP/1.1
[mc-image-helper] 15:42:30.946 DEBUG : JSON FETCH: uri=https://launchermeta.mojang.com/mc/game/version_manifest_v2.json headers=[user-agent: itzg/mc-image-helper/1.61.1 (cmd=resolve-minec]
[mc-image-helper] 15:42:31.844 WARN  : [ed74de27-1, L:/172.17.0.2:41996 ! R:launchermeta.mojang.com/150.171.110.52:443] The connection observed an error
reactor.netty.http.client.PrematureCloseException: Connection prematurely closed BEFORE response
[mc-image-helper] 15:42:32.181 ERROR : 'resolve-minecraft-version' command failed. Version is 1.61.1
```

Consulting with Gemini it sounds like some CDNs can be picky about the TLS negotiation where Java's default triggers anti-bot defense logic.

Improved from previous attempts:
- added netty-tcnative-boringssl-static to ensure openssl libraries are used
- increase window and frame size to improve file download speeds
- upgraded logback while I was here