### PR TITLE
fix: Added --help flag to InstallPaperCommand

### DIFF
--- a/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
+++ b/src/main/java/me/itzg/helpers/paper/InstallPaperCommand.java
@@ -41,6 +41,10 @@ import reactor.core.scheduler.Schedulers;
 @Slf4j
 public class InstallPaperCommand implements Callable<Integer> {
 
+    @SuppressWarnings("unused")
+    @Option(names = {"--help", "-h"}, usageHelp = true)
+    boolean help;
+
     @Option(names = "--check-updates", description = "Check for updates and exit with status code 0 when available")
     boolean requestCheckUpdates;
 


### PR DESCRIPTION
Whilst debugging another issue, i was using the `--help` flag over various install commands, and noticed Paper would fail `Unknown option: '--help'`

Oversight during the development of `InstallPaperCommand`, and a `--help` flag was never added!