### PR TITLE
Also use baked in API key for install-curseforge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,10 +143,9 @@ dependencies {
   }
 
   // https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle-bom
-  // stuck < 5.12.0 due to Java 8
-  testImplementation(platform("org.junit:junit-bom:[5.11.4,5.12.0)"))
-  testImplementation 'org.junit.jupiter:junit-jupiter'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  testImplementation(platform('org.junit:junit-bom:6.1.2'))
+  testImplementation('org.junit.jupiter:junit-jupiter')
+  testRuntimeOnly('org.junit.platform:junit-platform-launcher')
 
   testImplementation 'org.mockito:mockito-junit-jupiter:5.18.0'
   // https://github.com/wiremock/wiremock/releases/tag/3.0.0 drops support for Java 8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
+++ b/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
@@ -1,7 +1,12 @@
 package me.itzg.helpers.curseforge;
 
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.files.ObbyLoader;
 import org.slf4j.Logger;
 
+@Slf4j
 public class ApiKeyHelper {
 
     public static final String EXPECTED_API_KEY_PREFIX = "$2a$10$";
@@ -36,4 +41,25 @@ public class ApiKeyHelper {
             );
         }
     }
+
+    /**
+     * @throws InvalidParameterException if no API key is provided or cannot be loaded
+     */
+    public static String loadApiKey(String providedApiKey) {
+        if (providedApiKey != null && !providedApiKey.isBlank()) {
+            log.debug("Using provided CurseForge API key");
+            return providedApiKey.trim();
+        }
+
+        // properties file and property need to match the ObbyTask in build.gradle
+        final Map<String, String> cfApiProperties = ObbyLoader.loadProperties("/cf-api.properties");
+        final String loadedApiKey = cfApiProperties.get("cfApiKey");
+
+        if (loadedApiKey == null || loadedApiKey.isBlank()) {
+            throw new InvalidParameterException("CurseForge API key is required");
+        }
+        log.debug("Loaded CurseForge API key from cf-api.properties");
+        return loadedApiKey.trim();
+    }
+
 }

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
@@ -25,9 +25,7 @@ import me.itzg.helpers.curseforge.model.GetModResponse;
 import me.itzg.helpers.curseforge.model.ModsSearchResponse;
 import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidApiKeyException;
-import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.errors.RateLimitException;
-import me.itzg.helpers.files.ObbyLoader;
 import me.itzg.helpers.http.FailedRequestException;
 import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.FileDownloadStatusHandler;
@@ -70,39 +68,20 @@ public class CurseForgeApiClient implements AutoCloseable {
 
     private final ApiCaching apiCaching;
 
-    public CurseForgeApiClient(String apiBaseUrl, String providedApiKey, Options sharedFetchOptions, String gameId,
+    public CurseForgeApiClient(String apiBaseUrl, String apiKey, Options sharedFetchOptions, String gameId,
         ApiCaching apiCaching
     ) {
         this.apiCaching = apiCaching;
         this.preparedFetch = Fetch.sharedFetch("install-curseforge",
             (sharedFetchOptions != null ? sharedFetchOptions : Options.builder().build())
-                .withHeader(API_KEY_HEADER, loadApiKey(providedApiKey))
+                .withHeader(API_KEY_HEADER, apiKey)
         );
         this.uriBuilder = UriBuilder.withBaseUrl(apiBaseUrl);
         this.downloadFallbackUriBuilder = UriBuilder.withBaseUrl(
-            // Hardcoded conditional swap out of URL here helps mitigate the "manual download"
-            // challenge for those mods with a null download URL in their metadata.
-            apiBaseUrl.equals("https://api.curseforge.com") ?
-                "https://www.curseforge.com/api" : apiBaseUrl
+            // Refer to https://blog.curseforge.com/introducing-api-key-authentication-for-curseforge-file-downloads/
+            "https://edge.forgecdn.net"
         );
         this.gameId = gameId;
-    }
-
-    private String loadApiKey(String providedApiKey) {
-        if (providedApiKey != null && !providedApiKey.isBlank()) {
-            log.debug("Using provided CurseForge API key");
-            return providedApiKey.trim();
-        }
-
-        // properties file and property need to match the ObbyTask in build.gradle
-        final Map<String, String> cfApiProperties = ObbyLoader.loadProperties("/cf-api.properties");
-        final String loadedApiKey = cfApiProperties.get("cfApiKey");
-
-        if (loadedApiKey == null || loadedApiKey.isBlank()) {
-            throw new InvalidParameterException("CurseForge API key is required");
-        }
-        log.debug("Loaded CurseForge API key from cf-api.properties");
-        return loadedApiKey.trim();
     }
 
     static FileDownloadStatusHandler modFileDownloadStatusHandler(Path outputDir, Logger log) {
@@ -271,16 +250,36 @@ public class CurseForgeApiClient implements AutoCloseable {
     public Mono<Path> download(CurseForgeFile cfFile, Path outputFile, FileDownloadStatusHandler handler) {
         final URI uriToDownload = cfFile.getDownloadUrl() != null ?
             normalizeDownloadUrl(cfFile.getDownloadUrl())
-            : downloadFallbackUriBuilder.resolve(
-                "/v1/mods/{modId}/files/{fileId}/download",
-                cfFile.getModId(), cfFile.getId()
-            );
+            : buildFallbackUrl(cfFile);
         log.trace("Downloading cfFile={} from normalizedUrl={}", cfFile, uriToDownload);
         return preparedFetch.fetch(uriToDownload)
             .toFile(outputFile)
             .skipExisting(true)
             .handleStatus(handler)
             .assemble();
+    }
+
+    private URI buildFallbackUrl(CurseForgeFile cfFile) {
+        final String idStr = Integer.toString(cfFile.getId());
+
+        // In most (modern) cases a file ID like 8273779
+        // results in a URL path like /files/8273/779/cc-tweaked-1.21.1-forge-1.120.0.jar
+        final String idFolder;
+        final String idRemainder;
+        if (idStr.length() >= 7) {
+            idFolder = idStr.substring(0, 4);
+            idRemainder = idStr.substring(4);
+        }
+        else {
+            // legacy cases just divided the ID by 1000
+            idFolder = Integer.toString(cfFile.getId() / 1000);
+            idRemainder = idStr;
+        }
+
+        return downloadFallbackUriBuilder.resolve(
+            "/files/{id}/{subId}/{filename}",
+            idFolder, idRemainder, cfFile.getFileName()
+        );
     }
 
     public Mono<Path> downloadTemp(CurseForgeFile cfFile, String suffix, FileDownloadStatusHandler handler) {

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
@@ -74,7 +74,7 @@ public class CurseForgeApiClient implements AutoCloseable {
         this.apiCaching = apiCaching;
         this.preparedFetch = Fetch.sharedFetch("install-curseforge",
             (sharedFetchOptions != null ? sharedFetchOptions : Options.builder().build())
-                .withHeader(API_KEY_HEADER, apiKey)
+                .withHeader(API_KEY_HEADER, apiKey.trim())
         );
         this.uriBuilder = UriBuilder.withBaseUrl(apiBaseUrl);
         this.downloadFallbackUriBuilder = UriBuilder.withBaseUrl(

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeFilesCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeFilesCommand.java
@@ -1,5 +1,6 @@
 package me.itzg.helpers.curseforge;
 
+import static me.itzg.helpers.curseforge.ApiKeyHelper.loadApiKey;
 import static me.itzg.helpers.curseforge.CurseForgeApiClient.*;
 import static me.itzg.helpers.curseforge.ModFileRefResolver.idsFrom;
 import static me.itzg.helpers.singles.NormalizeOptions.normalizeOptionList;
@@ -128,7 +129,9 @@ public class CurseForgeFilesCommand implements Callable<Integer> {
                     : new ApiCachingImpl(outputDir, CACHING_NAMESPACE, cacheArgs)
                         .setCacheDurations(CurseForgeApiClient.getCacheDurations());
                 final CurseForgeApiClient apiClient = new CurseForgeApiClient(
-                    apiBaseUrl, apiKey, sharedFetchArgs.options(),
+                    apiBaseUrl,
+                    loadApiKey(apiKey),
+                    sharedFetchArgs.options(),
                     CurseForgeApiClient.MINECRAFT_GAME_ID,
                     apiCaching
                 )

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -3,6 +3,7 @@ package me.itzg.helpers.curseforge;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
+import static me.itzg.helpers.curseforge.ApiKeyHelper.loadApiKey;
 import static me.itzg.helpers.curseforge.CurseForgeApiClient.CACHING_NAMESPACE;
 import static me.itzg.helpers.curseforge.CurseForgeApiClient.modFileDownloadStatusHandler;
 import static me.itzg.helpers.singles.MoreCollections.safeStreamFrom;
@@ -211,27 +212,14 @@ public class CurseForgeInstaller {
         // to adapt to previous copies of manifest
         trimLevelsContent(manifest);
 
-        if (apiKey == null || apiKey.isEmpty()) {
-            if (manifest != null) {
-                log.warn("API key is not set, so will re-use previous modpack installation of {}",
-                    manifest.getSlug() != null ? manifest.getSlug() : "Project ID " + manifest.getModId()
-                );
-                log.warn("Obtain an API key from " + CurseForgeApiClient.ETERNAL_DEVELOPER_CONSOLE_URL
-                    + " and set the environment variable " + CurseForgeApiClient.API_KEY_VAR + " in order to restore full functionality.");
-                return;
-            }
-            else {
-                throw new InvalidParameterException("API key is not set. Obtain an API key from " + CurseForgeApiClient.ETERNAL_DEVELOPER_CONSOLE_URL
-                    + " and set the environment variable " + CurseForgeApiClient.API_KEY_VAR);
-            }
-        }
-
         try (
             final ApiCaching apiCaching = disableApiCaching ? new ApiCachingDisabled()
                 : new ApiCachingImpl(outputDir, CACHING_NAMESPACE, cacheArgs)
                     .setCacheDurations(CurseForgeApiClient.getCacheDurations());
             final CurseForgeApiClient cfApi = new CurseForgeApiClient(
-                apiBaseUrl, apiKey, sharedFetchOptions,
+                apiBaseUrl,
+                loadApiKey(apiKey),
+                sharedFetchOptions,
                 CurseForgeApiClient.MINECRAFT_GAME_ID,
                 apiCaching
             )


### PR DESCRIPTION
Follow up to #811

Also makes use of the URL mentioned in https://blog.curseforge.com/introducing-api-key-authentication-for-curseforge-file-downloads/

```
https://edge.forgecdn.net/files/{id}/{subId}/{filename}
```