### PR TITLE
modrinth: ensure beta dependencies don't mask explicit project request

### DIFF
--- a/.github/workflows/issues-notify.yml
+++ b/.github/workflows/issues-notify.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository_owner == 'itzg'
     uses: itzg/github-workflows/.github/workflows/issues-notify-discord.yml@main
     secrets:
       discordWebhook: "${{secrets.DISCORD_ISSUES_WEBHOOK}}"

--- a/.github/workflows/issues-notify.yml
+++ b/.github/workflows/issues-notify.yml
@@ -7,6 +7,9 @@ on:
       - labeled
       - unlabeled
       - closed
+  pull_request_target:
+    types:
+      - closed
 
 jobs:
   notify:

--- a/build.gradle
+++ b/build.gradle
@@ -169,8 +169,10 @@ githubReleaser {
   }
 }
 
+def generatedResourcesMain = 'generated/resources/main'
+
 tasks.register('obbyCfApi', ObbyTask, {
-  outputFile = layout.buildDirectory.file('generated/resources/main/cf-api.properties')
+  outputFile = layout.buildDirectory.file(generatedResourcesMain + '/cf-api.properties')
   clearTextProperties.set([
       // Bake in the CF_API_KEY is provided by the build
       'cfApiKey': project.findProperty('cfApiKey') as String ?: System.getenv('CF_API_KEY') ?: '',
@@ -180,7 +182,12 @@ tasks.register('obbyCfApi', ObbyTask, {
 sourceSets {
   main {
     resources {
-      srcDir(layout.buildDirectory.dir('generated/resources/main'))
+      // include obby generated resources in the main resources
+      srcDir(layout.buildDirectory.dir(generatedResourcesMain))
+    }
+    java {
+      // exclude sidecar design docs
+      exclude '**/*.md'
     }
   }
 }

--- a/dev/modrinth.http
+++ b/dev/modrinth.http
@@ -10,18 +10,36 @@ GET https://api.modrinth.com/v2/project/datacraft
 ### Nerbvival v5
 GET https://api.modrinth.com/v2/version/ayspYmZQ
 
+###
+@versionId =YPm4arUa
+GET https://api.modrinth.com/v2/version/{{versionId}}
+
 ### https://modrinth.com/modpack/better-mc-fabric-bmc2/version/v2
 # has a client mod incorrectly published
 GET https://api.modrinth.com/v2/version/8xwR1JNo
 
 ###
-GET https://api.modrinth.com/v2/projects?ids=["female-gender-spigot"]
+@project =techreborn
+GET https://api.modrinth.com/v2/projects?ids=["{{project}}"]
 
 ###
 GET https://api.modrinth.com/v2/projects?ids=["fabric-api","cloth-config"]
 
 ###
+GET https://api.modrinth.com/v2/projects?ids=["glitchcore","biomes-o-plenty"]
+
+###
+@id =biomes-o-plenty
+GET https://api.modrinth.com/v2/project/{{id}}/dependencies
+
+###
 GET https://api.modrinth.com/v2/project/ae2/version?loaders=fabric&game_versions=1.20.1
+
+###
+@projectId =3eMENr4V
+@loaders =fabric
+@gameVersion =1.21.1
+GET https://api.modrinth.com/v2/project/{{projectId}}/version?loaders=["{{loaders}}"]&game_versions=["{{gameVersion}}"]
 
 ###
 GET https://api.modrinth.com/v2/project/datacraft/version?loaders=neoforge&game_versions=1.20.1

--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.java
@@ -2,7 +2,6 @@ package me.itzg.helpers.modrinth;
 
 import static me.itzg.helpers.McImageHelper.SPLIT_COMMA_NL;
 import static me.itzg.helpers.McImageHelper.SPLIT_SYNOPSIS_COMMA_NL;
-import static me.itzg.helpers.http.Fetch.fetch;
 import static me.itzg.helpers.singles.NormalizeOptions.normalizeOptionList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +27,7 @@ import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.files.Manifests;
 import me.itzg.helpers.http.Fetch;
+import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.json.ObjectMappers;
 import me.itzg.helpers.modrinth.model.DependencyType;
@@ -115,6 +115,9 @@ public class ModrinthCommand implements Callable<Integer> {
 
     final Set<String/*projectId*/> projectsProcessed = Collections.synchronizedSet(new HashSet<>());
 
+    private final Set<String/*projectId*/> explicitProjectIds = new HashSet<>();
+    private final Set<String/*projectId*/> dependencyProjectsWithVersion = new HashSet<>();
+
     private final Map<String/*projectId*/, VersionType> allowedVersionTypesByProject = new HashMap<>();
 
     @Override
@@ -140,15 +143,15 @@ public class ModrinthCommand implements Callable<Integer> {
             return Collections.emptyList();
         }
 
-        final List<String> expandedRefs = expandProjectListings(projects);
-
-        // Separate optional from required so that bulkGetProjects can handle
-        // unknown optional slugs gracefully.
-        final List<ProjectRef> allRefs = expandedRefs.stream()
+        final List<ProjectRef> allRefs = expandProjectListings(projects).stream()
             .map(ProjectRef::parse)
-            .collect(Collectors.toList());
+            .toList();
 
-        try (ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, "modrinth", sharedFetchArgs.options())) {
+        log.debug("Processing input project refs: {}", allRefs);
+
+        try (
+            final SharedFetch sharedFetch = new SharedFetch("modrinth", sharedFetchArgs.options());
+            ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, sharedFetch)) {
             final List<ResolvedProject> resolvedProjects =
                 modrinthApiClient.bulkGetProjects(
                     allRefs.stream(),
@@ -164,6 +167,12 @@ public class ModrinthCommand implements Callable<Integer> {
             }
             log.trace("Resolved projects: {}", resolvedProjects);
 
+            explicitProjectIds.addAll(
+                resolvedProjects.stream()
+                    .map(resolvedProject -> resolvedProject.getProject().getId())
+                    .collect(Collectors.toSet())
+            );
+
             // tracking any user declared, per-project version type
             resolvedProjects.stream()
                 .filter(resolvedProject -> resolvedProject.getProjectRef().hasVersionType())
@@ -178,7 +187,7 @@ public class ModrinthCommand implements Callable<Integer> {
                 .flatMap(resolvedProject ->
                     processProject(
                         modrinthApiClient,
-                        resolvedProject.getProjectRef(),
+                        sharedFetch, resolvedProject.getProjectRef(),
                         resolvedProject.getProject()
                     )
                 )
@@ -242,7 +251,7 @@ public class ModrinthCommand implements Callable<Integer> {
         log.debug("Expanding dependencies of version={}", version);
         return version.getDependencies().stream()
             .filter(this::filterDependency)
-            .filter(dep -> trackProjectProcessed(dep.getProjectId()))
+            .filter(this::trackDependencyProjectProcessed)
             .flatMap(dep -> {
                 final Version depVersion;
                 try {
@@ -281,7 +290,6 @@ public class ModrinthCommand implements Callable<Integer> {
                     return Stream.empty();
                 }
             });
-
     }
 
     /**
@@ -291,6 +299,39 @@ public class ModrinthCommand implements Callable<Integer> {
         final boolean absent = projectsProcessed.add(projectId);
         log.debug("Project {} was {} processed", projectId, absent ? "not" : "already");
         return absent;
+    }
+
+    /**
+     * Enforces precedence rules for dependencies:
+     * <ul>
+     *     <li>Explicitly requested projects take precedence over dependencies.</li>
+     *     <li>A dependency with version_id takes precedence over one without version_id.</li>
+     * </ul>
+     */
+    private boolean trackDependencyProjectProcessed(VersionDependency dep) {
+        final String projectId = dep.getProjectId();
+
+        if (explicitProjectIds.contains(projectId)) {
+            log.debug("Skipping dependency={} because project={} was explicitly requested", dep, projectId);
+            return false;
+        }
+
+        if (dep.getVersionId() != null) {
+            final boolean firstVersionedDependency = dependencyProjectsWithVersion.add(projectId);
+            if (firstVersionedDependency && projectsProcessed.contains(projectId)) {
+                // Prefer the version-pinned dependency over previously seen unpinned dep.
+                log.debug("Replacing previously processed unpinned dependency for project={}", projectId);
+                projectsProcessed.remove(projectId);
+            }
+            return trackProjectProcessed(projectId);
+        }
+
+        if (dependencyProjectsWithVersion.contains(projectId)) {
+            log.debug("Skipping dependency={} because a versioned dependency already exists for project={}", dep, projectId);
+            return false;
+        }
+
+        return trackProjectProcessed(projectId);
     }
 
     private boolean filterDependency(VersionDependency dep) {
@@ -320,7 +361,7 @@ public class ModrinthCommand implements Callable<Integer> {
         return null;
     }
 
-    private Path download(Loader loader, VersionFile versionFile) {
+    private Path download(SharedFetch sharedFetch, Loader loader, VersionFile versionFile) {
         final Path outPath;
         try {
             final Loader effectiveLoader = loader != null ? loader : this.loader;
@@ -354,7 +395,7 @@ public class ModrinthCommand implements Callable<Integer> {
         }
 
         try {
-            return fetch(URI.create(versionFile.getUrl()))
+            return sharedFetch.fetch(URI.create(versionFile.getUrl()))
                 .userAgentCommand("modrinth")
                 .toFile(outPath)
                 .skipExisting(skipExisting)
@@ -378,7 +419,7 @@ public class ModrinthCommand implements Callable<Integer> {
     }
 
 
-    private Stream<Path> processProject(ModrinthApiClient modrinthApiClient, ProjectRef projectRef, Project project) {
+    private Stream<Path> processProject(ModrinthApiClient modrinthApiClient, SharedFetch sharedFetch, ProjectRef projectRef, Project project) {
         if (project.getProjectType() != ProjectType.mod) {
             throw new InvalidParameterException(
                 String.format("Requested project '%s' is not a mod, but has type %s",
@@ -386,7 +427,7 @@ public class ModrinthCommand implements Callable<Integer> {
                 ));
         }
 
-        log.debug("Starting with project='{}' slug={} id={} optional={}", project.getTitle(), project.getSlug(), project.getId(), projectRef.isOptional());
+        log.debug("Starting with project='{}' optional={}", project, projectRef.isOptional());
 
         if (trackProjectProcessed(project.getId())) {
             final Loader effectiveLoader = projectRef.getLoader() != null
@@ -434,7 +475,7 @@ public class ModrinthCommand implements Callable<Integer> {
                     )
                 )
                     .map(ModrinthApiClient::pickVersionFile)
-                    .map(versionFile -> download(effectiveLoader, versionFile))
+                    .map(versionFile -> download(sharedFetch, effectiveLoader, versionFile))
                     .flatMap(downloadedFile -> {
                         // Only expand ZIPs for non-datapack loaders
                         return effectiveLoader == Loader.datapack

--- a/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.md
+++ b/src/main/java/me/itzg/helpers/modrinth/ModrinthCommand.md
@@ -1,0 +1,69 @@
+## Dependency resolution
+
+Some rules and behaviors:
+
+- project entry provided by user may reference a file that contains a list of project entries
+- projects should be retrieved in bulk where possible, which is more feasible since only ID or slug is needed
+- explicit project references given by user take precedence over dependencies
+  - can override version type
+  - can override loader
+- avoid cycles
+- a dependency ref that indicates version takes precedence over a ref that does not indicate version
+- user may choose to download only required dependencies, optional ones also, or none at all
+- user declares global allowed version type (release > beta > alpha)
+- user declares global loader, such as paper, forge
+- each Loader enum declares compatible loader types and those are hierarchical, such as pufferfish → paper → spigot
+
+### Model and providers
+
+```mermaid
+classDiagram
+    class Project
+    class ProjectRef
+    class ResolvedProject
+    ResolvedProject *-- Project
+    ResolvedProject *-- ProjectRef
+    class Version
+    class VersionDependency {
+        +String projectId
+        +String? versionId
+    }
+    Version *-- "*" VersionDependency
+    
+    class ModrinthApiClient {
+        +getVersionFromId(versionId: String) Version
+        +getVersionsForProject(String projectIdOrSlug, @Nullable Loader loader, String gameVersion) List~Version~
+        +bulkGetProjects(projectRefs) List~ResolvedProject~
+        +getProject(projectIdOrSlug: String) Project
+    }
+```
+
+```mermaid
+flowchart TD
+    subgraph ModrinthApiClient 
+        getVersionFromId
+        getVersionsForProject
+        bulkGetProjects
+        getProject
+    end
+    subgraph model 
+        Version
+        Project
+        VersionDependency
+    end
+    getVersionFromId[[getVersionFromId]]
+    versionId --> getVersionFromId --> Version
+    
+    getVersionsForProject[[getVersionsForProject]]
+    projectIdOrSlug --> getVersionsForProject
+    loader -- optional --> getVersionsForProject
+    gameVersion --> getVersionsForProject
+    getVersionsForProject -- N --> Version
+    
+    bulkGetProjects[[bulkGetProjects]]
+    projectRefs --> bulkGetProjects --> ResolvedProject
+    optionalSlugs --> bulkGetProjects
+    
+    getProject[[getProject]]
+    projectIdOrSlug --> getProject --> Project
+```

--- a/src/main/java/me/itzg/helpers/modrinth/model/Project.java
+++ b/src/main/java/me/itzg/helpers/modrinth/model/Project.java
@@ -4,26 +4,34 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
 import lombok.Data;
+import lombok.ToString;
 
 /**
  * <a href="https://docs.modrinth.com/api/operations/getproject/#200">Spec</a>
  */
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ToString(onlyExplicitlyIncluded = true)
 public class Project {
-  String slug;
 
-  String id;
+    @ToString.Include
+    String slug;
 
-  String title;
+    @ToString.Include
+    String id;
 
-  ProjectType projectType;
+    @ToString.Include
+    String title;
 
-  ServerSide serverSide;
+    @ToString.Include
+    ProjectType projectType;
 
-  List<String> versions;
+    @ToString.Include
+    ServerSide serverSide;
 
-  List<String> gameVersions;
+    List<String> versions;
 
-  List<String> loaders;
+    List<String> gameVersions;
+
+    List<String> loaders;
 }

--- a/src/main/java/me/itzg/helpers/modrinth/model/Version.java
+++ b/src/main/java/me/itzg/helpers/modrinth/model/Version.java
@@ -5,21 +5,27 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.time.Instant;
 import java.util.List;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ToString(onlyExplicitlyIncluded = true)
 public class Version {
 
+    @ToString.Include
     private String id;
 
+    @ToString.Include
     private String projectId;
 
+    @ToString.Include
     private String name;
 
     private Instant datePublished;
 
     private String versionNumber;
 
+    @ToString.Include
     private VersionType versionType;
 
     private List<VersionFile> files;

--- a/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/ModrinthCommandTest.java
@@ -12,8 +12,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.function.Consumer;
 import me.itzg.helpers.LatchingExecutionExceptionHandler;
@@ -25,6 +27,7 @@ import me.itzg.helpers.modrinth.model.ProjectType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.AbstractPathAssert;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,6 +38,9 @@ import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 
 class ModrinthCommandTest {
+
+    public static final String PROJECT_ID_GLITCHCORE = "s3dmwKy5";
+    public static final String PROJECT_ID_BIOMES_O_PLENTY = "YPm4arUa";
     final ObjectMapper objectMapper = ObjectMappers.defaultMapper();
 
     @RegisterExtension
@@ -106,7 +112,7 @@ class ModrinthCommandTest {
 
         stubProjectBulkRequest(projectId, projectSlug);
 
-        stubVersionRequest(projectId, versionId, deps -> {
+        stubProjectVersionRequestForOne(projectId, versionId, deps -> {
             deps.addObject()
                 .put("project_id", requiredDepProjectId)
                 .put("dependency_type", "required");
@@ -114,10 +120,10 @@ class ModrinthCommandTest {
                 .put("project_id", optionalDepProjectId)
                 .put("dependency_type", "optional");
         });
-        stubVersionRequest(requiredDepProjectId, requiredVersionId, deps -> {});
-        stubVersionRequest(optionalDepProjectId, optionalVersionId, deps -> {});
+        stubProjectVersionRequestForOne(requiredDepProjectId, requiredVersionId, deps -> {});
+        stubProjectVersionRequestForOne(optionalDepProjectId, optionalVersionId, deps -> {});
 
-        stubDownload();
+        stubAnyDownload();
 
         final int exitCode = new CommandLine(
             new ModrinthCommand()
@@ -172,7 +178,7 @@ class ModrinthCommandTest {
 
         stubProjectBulkRequest(projectId, projectSlug);
 
-        stubVersionRequest(projectId, versionId, deps ->
+        stubProjectVersionRequestForOne(projectId, versionId, deps ->
             deps.addObject()
             .put("project_id", requiredDepProjectId)
             .put("dependency_type", "required")
@@ -181,7 +187,7 @@ class ModrinthCommandTest {
         stubVersionRequestEmptyResponse(requiredDepProjectId, "spigot");
         stubGetProject(requiredDepProjectId, new Project().setProjectType(ProjectType.resourcepack));
 
-        stubDownload();
+        stubAnyDownload();
 
         final LatchingExecutionExceptionHandler executionExceptionHandler = new LatchingExecutionExceptionHandler();
 
@@ -466,6 +472,146 @@ class ModrinthCommandTest {
         }
     }
 
+    @Test
+    void ensureBetaDependencySkipped(@TempDir Path tempDir) {
+        stubProjectBulkRequestMulti("biomes-o-plenty", PROJECT_ID_BIOMES_O_PLENTY);
+        // biomes-o-plenty
+        stubVersionRequest(PROJECT_ID_BIOMES_O_PLENTY, deps -> {
+            addDependency(deps, "required",
+                // glitchcore
+                PROJECT_ID_GLITCHCORE, null);
+        }, files -> {
+            addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/YPm4arUa", "biomes-o-plenty-1.0.0.jar");
+        });
+        stubProjectVersionsRequest(PROJECT_ID_GLITCHCORE, "fabric", "1.21.1", versions -> {
+            addProjectVersion(versions, "FsKFwxzd", PROJECT_ID_GLITCHCORE, "beta", new String[]{"fabric"},
+                files -> {
+                addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/FsKFwxzd", "glitchcore-1.0.0.jar");
+            }, deps -> {});
+        });
+        stubAnyDownload();
+
+        final int exitCode = new CommandLine(
+            new ModrinthCommand()
+        )
+            .execute(
+                "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
+                "--output-directory", tempDir.toString(),
+                "--game-version", "1.21.1",
+                "--loader", "fabric",
+                "--download-dependencies", DownloadDependencies.REQUIRED.name(),
+                "--projects",
+                "biomes-o-plenty:YPm4arUa"
+            );
+
+        assertThat(exitCode).isEqualTo(ExitCode.OK);
+        assertThat(tempDir.resolve("mods/biomes-o-plenty-1.0.0.jar")).exists();
+        verifyVersionRequest(PROJECT_ID_BIOMES_O_PLENTY);
+
+        assertThat(tempDir.resolve("mods")).isDirectoryNotContaining(path -> path.getFileName().toString().startsWith("glitchcore"));
+        // glitchcore with beta
+        verifyProjectVersionsRequest(PROJECT_ID_GLITCHCORE, "fabric", "1.21.1");
+    }
+
+    @Test
+    void ensureBetaDependencyDoesntMaskExplicitProject(@TempDir Path tempDir) {
+        /*
+         * bug: glitchcore was getting skipped since biomes-o-plenty depends on glitchcore, but only betas are available
+         * inputs:
+         *       Loader: fabric
+         *       Minecraft version: 1.21.1
+         *       MODRINTH_PROJECTS: |-
+         *         biomes-o-plenty:YPm4arUa
+         *         glitchcore:FsKFwxzd
+         */
+
+        stubProjectBulkRequestMulti("glitchcore", PROJECT_ID_GLITCHCORE, "biomes-o-plenty", PROJECT_ID_BIOMES_O_PLENTY);
+        // glitchore
+        stubVersionRequest("FsKFwxzd", deps -> {
+        }, files -> {
+            addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/"
+                + PROJECT_ID_GLITCHCORE, "glitchcore-1.0.0.jar");
+        });
+        // biomes-o-plenty
+        stubVersionRequest(PROJECT_ID_BIOMES_O_PLENTY, deps -> {
+            addDependency(deps, "required", PROJECT_ID_GLITCHCORE, null);
+        }, files -> {
+            addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/" + PROJECT_ID_BIOMES_O_PLENTY, "biomes-o-plenty-1.0.0.jar");
+        });
+        stubAnyDownload();
+
+        final int exitCode = new CommandLine(
+            new ModrinthCommand()
+        )
+            .execute(
+                "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
+                "--output-directory", tempDir.toString(),
+                "--game-version", "1.21.1",
+                "--loader", "fabric",
+                "--download-dependencies", DownloadDependencies.REQUIRED.name(),
+                "--projects",
+                    "biomes-o-plenty:YPm4arUa"
+                    + ",glitchcore:FsKFwxzd"
+            );
+
+        assertThat(exitCode).isEqualTo(ExitCode.OK);
+        assertThat(tempDir.resolve("mods/glitchcore-1.0.0.jar")).exists();
+        assertThat(tempDir.resolve("mods/biomes-o-plenty-1.0.0.jar")).exists();
+    }
+
+    @Test
+    void handlesDependencyChain(@TempDir Path tempDir) throws IOException {
+        // such as Tech Reborn ──> requires RebornCore ──> requires Fabric API
+        // techreborn(3eMENr4V) -> reborncore(3NCrJdj3) -> fabric-api(P7dR8mSH)
+        // NOTE: normally techreborn (like most) depends on fabric-api, but for this test, we are going to make it depend on reborncore instead, which will then depend on fabric-api
+
+        stubProjectBulkRequestMulti(
+            "techreborn", "3eMENr4V"
+        );
+        stubProjectVersionsRequest("3eMENr4V", "fabric", "1.21.1", versions -> {
+            addProjectVersion(versions, "3eMENr4V", "3eMENr4V", "release", new String[]{"fabric"},
+                files -> {
+                addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/3eMENr4V", "techreborn-1.0.0.jar");
+            }, deps -> {
+                addDependency(deps, "required", "3NCrJdj3", null);
+            });
+        });
+        stubProjectVersionsRequest("3NCrJdj3", "fabric", "1.21.1", versions -> {
+            addProjectVersion(versions, "3NCrJdj3", "3NCrJdj3", "release", new String[]{"fabric"},
+                files -> {
+                addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/3NCrJdj3", "reborncore-1.0.0.jar");
+            }, deps -> {
+                addDependency(deps, "required", "P7dR8mSH", null);
+            });
+        });
+        stubProjectVersionsRequest("P7dR8mSH", "fabric", "1.21.1", versions -> {
+            addProjectVersion(versions, "P7dR8mSH", "P7dR8mSH", "release", new String[]{"fabric"},
+                files -> {
+                addFile(files, wm.getRuntimeInfo().getHttpBaseUrl() + "/cdn/P7dR8mSH", "fabric-api-1.0.0.jar");
+            }, deps -> {});
+        });
+        stubAnyDownload();
+
+        final int exitCode = new CommandLine(
+            new ModrinthCommand()
+        )
+            .execute(
+                "--api-base-url", wm.getRuntimeInfo().getHttpBaseUrl(),
+                "--output-directory", tempDir.toString(),
+                "--game-version", "1.21.1",
+                "--loader", "fabric",
+                "--download-dependencies", DownloadDependencies.REQUIRED.name(),
+                "--projects",
+                "techreborn"
+            );
+
+        assertThat(exitCode).isEqualTo(ExitCode.OK);
+        final Path modsDir = tempDir.resolve("mods");
+        assertThat(modsDir.resolve("techreborn-1.0.0.jar")).exists();
+        assertThat(modsDir.resolve("reborncore-1.0.0.jar")).exists();
+        assertThat(modsDir.resolve("fabric-api-1.0.0.jar")).exists();
+    }
+
     @NotNull
     private static RequestPatternBuilder projectVersionsRequest(String projectId) {
         return getRequestedFor(urlPathEqualTo("/v2/project/" + projectId + "/version"));
@@ -493,6 +639,30 @@ class ModrinthCommandTest {
         );
     }
 
+    private void stubProjectBulkRequestMulti(String... projectsSlugsIds) {
+        final ArrayNode projectResp = objectMapper.createArrayNode();
+        assertThat(projectsSlugsIds.length % 2).isEqualTo(0);
+        final ArrayList<String> projects = new ArrayList<>();
+        for (int i = 0; i < projectsSlugsIds.length; i +=2) {
+            final String projectSlug = projectsSlugsIds[i];
+            final String projectId = projectsSlugsIds[i+1];
+            projects.add(projectSlug);
+            projectResp
+                .addObject()
+                .put("id", projectId)
+                .put("slug", projectSlug)
+                .put("project_type", "mod")
+                .put("server_side", "required");
+        }
+        stubFor(get(urlPathEqualTo("/v2/projects"))
+            .withQueryParam("ids", equalTo("[\"" + String.join("\",\"", projects) + "\"]"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withJsonBody(projectResp)
+            )
+        );
+    }
+
     private void stubGetProject(String projectIdOrSlug, Project project) throws JsonProcessingException {
         stubFor(get(urlPathEqualTo("/v2/project/"+projectIdOrSlug))
             .willReturn(aResponse()
@@ -502,7 +672,7 @@ class ModrinthCommandTest {
         );
     }
 
-    private void stubVersionRequest(String projectId, String versionId, Consumer<ArrayNode> depsAdder) {
+    private void stubProjectVersionRequestForOne(String projectId, String versionId, Consumer<ArrayNode> depsAdder) {
         final ArrayNode versionResp = objectMapper.createArrayNode();
         final ObjectNode versionNode = versionResp
             .addObject()
@@ -526,6 +696,66 @@ class ModrinthCommandTest {
         );
     }
 
+    private void stubProjectVersionsRequest(String projectId, String loader, String mcVersion, Consumer<ArrayNode> projectVersionAdder) {
+        final ArrayNode versionResp = objectMapper.createArrayNode();
+        projectVersionAdder.accept(versionResp);
+
+        stubFor(get(urlPathEqualTo("/v2/project/" + projectId + "/version"))
+            .withQueryParam("loaders", equalTo("[\"" + loader + "\"]"))
+            .withQueryParam("game_versions", equalTo("[\"" + mcVersion + "\"]"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withJsonBody(versionResp)
+            )
+        );
+    }
+
+    private void addProjectVersion(ArrayNode projects, String versionId, String projectId, String versionType, String[] loaders,
+        Consumer<ArrayNode> filesAdder, Consumer<ArrayNode> depsAdder) {
+        final ObjectNode versionNode = projects.addObject()
+            .put("id", versionId)
+            .put("project_id", projectId)
+            .put("version_type", versionType);
+        final ArrayNode loadersArray = versionNode.putArray("loaders");
+        for (String loader : loaders) {
+            loadersArray.add(loader);
+        }
+
+        final ArrayNode files = versionNode.putArray("files");
+        filesAdder.accept(files);
+
+        final ArrayNode dependencies = versionNode.putArray("dependencies");
+        depsAdder.accept(dependencies);
+    }
+
+    private void addDependency(ArrayNode deps, String dependencyType, String projectId, @Nullable String versionId) {
+        final ObjectNode dep = deps.addObject();
+        dep.put("dependency_type", dependencyType);
+        dep.put("project_id", projectId);
+        dep.put("version_id", versionId);
+    }
+
+    private void addFile(ArrayNode files, String url, String filename) {
+        final ObjectNode file = files.addObject();
+        file.put("url", url);
+        file.put("filename", filename);
+    }
+
+    private void stubVersionRequest(String versionId, Consumer<ArrayNode> depsAdder, Consumer<ArrayNode> filesAdder) {
+        final ObjectNode body = objectMapper.createObjectNode();
+        final ArrayNode deps = body.putArray("dependencies");
+        depsAdder.accept(deps);
+        final ArrayNode files = body.putArray("files");
+        filesAdder.accept(files);
+
+        stubFor(get(urlPathEqualTo("/v2/version/" + versionId))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withJsonBody(body)
+            )
+        );
+    }
+
     private void stubVersionRequestEmptyResponse(String projectId, String loader) {
         final ArrayNode versionResp = objectMapper.createArrayNode();
 
@@ -539,7 +769,7 @@ class ModrinthCommandTest {
         );
     }
 
-    private static void stubDownload() {
+    private static void stubAnyDownload() {
         stubFor(get(urlPathMatching("/cdn/(.+)"))
             .willReturn(aResponse()
                 .withBody("{{request.pathSegments.[1]}}")
@@ -584,4 +814,16 @@ class ModrinthCommandTest {
                 )
         );
     }
+
+    private static void verifyProjectVersionsRequest(String projectId, String loader, String mcVersion) {
+        verify(exactly(1), getRequestedFor(urlPathEqualTo("/v2/project/" + projectId + "/version"))
+            .withQueryParam("loaders", equalTo("[\"" + loader + "\"]"))
+            .withQueryParam("game_versions", equalTo("[\"" + mcVersion + "\"]"))
+        );
+    }
+
+    private static void verifyVersionRequest(String versionId) {
+        verify(exactly(1), getRequestedFor(urlPathEqualTo("/v2/version/" + versionId)));
+    }
+
 }


### PR DESCRIPTION
Resolves an issue [reported in Discord](https://discord.com/channels/660567679458869252/660569755320844308/1525875196643512340)

```yaml
services:
  mc:
    image: itzg/minecraft-server:java21
    tty: true
    stdin_open: true
    ports:
      - "25565:25565"
    environment:
      EULA: "TRUE"
      TYPE: "FABRIC"
      VERSION: "1.21.1"
      MEMORY: "5120M"
      MAX_PLAYERS: "4"
      ONLINE_MODE: "false"
      DIFFICULTY: "0"
      MODE: "1"
      SIMULATION_DISTANCE: "6"
      VIEW_DISTANCE: "6"
      OPS: |-
        FlitPix
      MODRINTH_PROJECTS: |-
        fabric-api:IpaMcBLh
        explorers-compass:qSRKiE4D
        oh-the-biomes-weve-gone:2VrEUzij
        incendium:8BLCOi4u
        biomes-o-plenty:YPm4arUa
        corgilib:ltZXAkMW
        glitchcore:FsKFwxzd
        geckolib:3GjkJptS
        terrablender:XNtIBXyQ
      MODRINTH_DOWNLOAD_DEPENDENCIES: "required"
```

User reported
- does not download glitchcore or terrablender despite them both being explicitly listed

It was because glitchcore (and others) only had beta versions available and it was first seen as a dependency of biomes-o-plenty. Then when glitchcore was processed later in the user list it skipped since it's tracking determined it has already been considered.