### PR TITLE
patch: name the file that could not be read for a placeholder value

### DIFF
--- a/src/main/java/me/itzg/helpers/env/Interpolator.java
+++ b/src/main/java/me/itzg/helpers/env/Interpolator.java
@@ -75,8 +75,17 @@ public class Interpolator {
     }
 
     private String readValueFromFile(String filename) throws IOException {
-        final String content = new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8);
-        return content.trim();
+        final byte[] content;
+        try {
+            content = Files.readAllBytes(Paths.get(filename));
+        } catch (IOException e) {
+            // Without the file name here, the failure gets reported against whatever file the
+            // caller was processing, which is not the file that could not be read.
+            throw new IOException(
+                String.format("Failed to read placeholder value from %s (%s)", filename, e.getMessage()), e
+            );
+        }
+        return new String(content, StandardCharsets.UTF_8).trim();
     }
 
     public Result<byte[]> interpolate(byte[] content) throws IOException {

--- a/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
+++ b/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
@@ -87,7 +87,10 @@ public class PatchSetProcessor {
                         }
                     }
                 } catch (IOException e) {
-                    log.warn("Failed to read content of {}: {}", filePath, e.getMessage());
+                    // Not necessarily a failure to read filePath: applying the ops can also read
+                    // other files, such as the *_FILE source of a placeholder value.
+                    log.warn("Failed to apply patch from {} to {}: {}",
+                        patch.getSrc(), filePath, e.getMessage());
                     log.debug("Details", e);
                 }
             }

--- a/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
+++ b/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
@@ -1,12 +1,15 @@
 package me.itzg.helpers.env;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import me.itzg.helpers.env.Interpolator.Result;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,5 +45,20 @@ class InterpolatorTest {
         assertThat(result.getContent())
             .isEqualTo("Interpolate this: $(SOME_VALUE)");
 
+    }
+
+    @Test
+    void reportsFileNameWhenValueFileCannotBeRead(@TempDir Path tempDir) {
+        // A directory is the typical case: container engines create a missing bind-mount source
+        // as a directory, so the *_FILE path exists but cannot be read as a value.
+        when(varProvider.get("CFG_SECRET_FILE"))
+            .thenReturn(tempDir.toString());
+
+        final Interpolator interpolator = new Interpolator(varProvider, "CFG_");
+
+        assertThatThrownBy(() -> interpolator.interpolate("${CFG_SECRET}"))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining(tempDir.toString())
+            .hasCauseInstanceOf(IOException.class);
     }
 }


### PR DESCRIPTION
Addresses the reporting half of #824. Semantics are deliberately left unchanged, so this can go
in independently of the behaviour change proposed there.

### Problem

`Interpolator.readValueFromFile` let the `IOException` from `Files.readAllBytes` propagate bare.
It is not a `MissingVariablesException`, so it was not handled at `PatchSetProcessor.java:186` and
instead surfaced at the `catch (IOException)` around the whole read-apply-write block. That
handler assumes the failure concerned the patch target, so the warning named the target file —
which is usually perfectly readable — and never mentioned the file that actually failed.

With `CFG_MY_SECRET_FILE` pointing at a directory (see the issue for why this is a common
accident), released 1.63.1 reports:

```
WARN : Failed to read content of /tmp/repro/target.yml: Is a directory
```

`target.yml` is a readable regular file. Nothing in the log points at the placeholder source.

### Change

- Wrap the failure in `readValueFromFile` with the file name and the underlying reason.
- Reword the warning in `processPatch` so it no longer claims the target was unreadable — the
  same `catch` also covers I/O performed while applying the ops.

The same run now reports:

```
WARN : Failed to apply patch from /tmp/repro/defs/test.json to /tmp/repro/target.yml: \
       Failed to read placeholder value from /tmp/repro/secret-as-dir (Is a directory)
```

The patch definition, the target and the file that actually failed are all named.

### Not changed

The patch is still skipped with a warning and exit code 0, and the ops that were applied before
the failure are still discarded. #824 proposes making that case fail outright instead; this PR
deliberately does not change it.

### Verified

- `./gradlew test` — 488 tests across 74 classes, all green (JDK 21 toolchain).
- The added test `InterpolatorTest.reportsFileNameWhenValueFileCannotBeRead` fails on `main`
  without the `Interpolator` change and passes with it (checked both ways).
- End-to-end via `installDist`, reproducing with a `*_FILE` variable pointing at a directory.
