### PR TITLE
Fail when a placeholder value file cannot be read

### DIFF
--- a/src/main/java/me/itzg/helpers/env/Interpolator.java
+++ b/src/main/java/me/itzg/helpers/env/Interpolator.java
@@ -12,6 +12,7 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.CharsetDetector;
+import me.itzg.helpers.errors.InvalidParameterException;
 
 @Slf4j
 public class Interpolator {
@@ -79,10 +80,11 @@ public class Interpolator {
         try {
             content = Files.readAllBytes(Paths.get(filename));
         } catch (IOException e) {
-            // Without the file name here, the failure gets reported against whatever file the
-            // caller was processing, which is not the file that could not be read.
-            throw new IOException(
-                String.format("Failed to read placeholder value from %s (%s)", filename, e.getMessage()), e
+            // A declared value source that cannot be read is a configuration error rather than
+            // something to continue past: callers would otherwise carry on and produce a result
+            // that is missing the very value this file was named to supply.
+            throw new InvalidParameterException(
+                String.format("Failed to read placeholder value from %s", filename), e, true
             );
         }
         return new String(content, StandardCharsets.UTF_8).trim();

--- a/src/main/java/me/itzg/helpers/env/Interpolator.java
+++ b/src/main/java/me/itzg/helpers/env/Interpolator.java
@@ -75,8 +75,17 @@ public class Interpolator {
     }
 
     private String readValueFromFile(String filename) throws IOException {
-        final String content = new String(Files.readAllBytes(Paths.get(filename)), StandardCharsets.UTF_8);
-        return content.trim();
+        final byte[] content;
+        try {
+            content = Files.readAllBytes(Paths.get(filename));
+        } catch (IOException e) {
+            // Without the file name here, the failure gets reported against whatever file the
+            // caller was processing, which is not the file that could not be read.
+            throw new IOException(
+                String.format("Failed to read placeholder value from %s (%s)", filename, e.getMessage()), e
+            );
+        }
+        return new String(content, StandardCharsets.UTF_8).trim();
     }
 
     public Result<byte[]> interpolate(byte[] content) throws IOException {

--- a/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
+++ b/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
@@ -87,7 +87,10 @@ public class PatchSetProcessor {
                         }
                     }
                 } catch (IOException e) {
-                    log.warn("Failed to read content of {}: {}", filePath, e.getMessage());
+                    // Not necessarily a failure to read filePath: applying the ops can also read
+                    // other files, such as the *_FILE source of a placeholder value.
+                    log.warn("Failed to apply patch from {} to {}: {}",
+                        patch.getSrc(), filePath, e.getMessage());
                     log.debug("Details", e);
                 }
             }

--- a/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
+++ b/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.file.Path;
 import me.itzg.helpers.env.Interpolator.Result;
+import me.itzg.helpers.errors.InvalidParameterException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -48,7 +49,7 @@ class InterpolatorTest {
     }
 
     @Test
-    void reportsFileNameWhenValueFileCannotBeRead(@TempDir Path tempDir) {
+    void failsWhenValueFileCannotBeRead(@TempDir Path tempDir) {
         // A directory is the typical case: container engines create a missing bind-mount source
         // as a directory, so the *_FILE path exists but cannot be read as a value.
         when(varProvider.get("CFG_SECRET_FILE"))
@@ -57,7 +58,7 @@ class InterpolatorTest {
         final Interpolator interpolator = new Interpolator(varProvider, "CFG_");
 
         assertThatThrownBy(() -> interpolator.interpolate("${CFG_SECRET}"))
-            .isInstanceOf(IOException.class)
+            .isInstanceOf(InvalidParameterException.class)
             .hasMessageContaining(tempDir.toString())
             .hasCauseInstanceOf(IOException.class);
     }

--- a/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
+++ b/src/test/java/me/itzg/helpers/env/InterpolatorTest.java
@@ -1,12 +1,15 @@
 package me.itzg.helpers.env;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import me.itzg.helpers.env.Interpolator.Result;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,5 +45,20 @@ class InterpolatorTest {
         assertThat(result.getContent())
             .isEqualTo("Interpolate this: $(SOME_VALUE)");
 
+    }
+
+    @Test
+    void reportsFileNameWhenValueFileCannotBeRead(@TempDir Path tempDir) {
+        // A directory is the typical case: container engines create a missing bind-mount source
+        // as a directory, so the *_FILE path exists but cannot be read as a value.
+        when(varProvider.get("CFG_SECRET_FILE"))
+            .thenReturn(tempDir.toString());
+
+        final Interpolator interpolator = new Interpolator(varProvider, "CFG_");
+
+        assertThatThrownBy(() -> interpolator.interpolate("${CFG_SECRET}"))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining(tempDir.toString())
+            .hasCauseInstanceOf(IOException.class);
     }
 }


### PR DESCRIPTION
Implements the fix proposed in #824.

Stacked on #825: its commit is the first of the two here. If you would rather take only the
reporting fix, merge #825 and close this one — nothing else depends on it.

### Change

`readValueFromFile` throws `InvalidParameterException(message, cause, true)` instead of a bare
`IOException` when the named `*_FILE` source cannot be read. Because it is unchecked it bypasses
the tolerant `catch (IOException)` in `PatchSetProcessor.processPatch`, and `ExceptionHandler`
renders it with its causal chain and no stack trace, exiting `2` through
`@EmitsExitCode(ExitCode.USAGE)`. This is the treatment `PatchOperationException` already gets at
`PatchSetProcessor.java:76-78`, so no new machinery is involved.

The `*_FILE`-unset case is untouched and keeps its skip-and-warn behaviour.

### Scope

`Interpolator` is shared by `patch`, `interpolate` and `sync-and-interpolate`, so all three now
stop instead of continuing when a value file they were told to read cannot be read.

### Before / after

With `CFG_MY_SECRET_FILE` pointing at a directory:

```
# before (1.63.1)
WARN : Failed to read content of /tmp/repro/target.yml: Is a directory
rc=0        # server starts, target file left entirely unpatched

# after
ERROR : 'patch' command failed. Version is ...: InvalidParameterException: Failed to read \
        placeholder value from /tmp/repro/secret-as-dir; IOException: Is a directory
rc=2
```

With the variable unset, unchanged:

```
WARN : Unable to set '$.proxies.velocity.secret' due to missing environment variables: [CFG_MY_SECRET]
rc=0        # remaining ops still applied
```

### Compatibility

This converts a silent misconfiguration into a start-up failure, which is the point, but it will
surface in deployments that are already broken without knowing it — most commonly a bind mount
whose host source does not exist, which the container engine creates as a directory. Might be
worth a release note.

### Verified

- `./gradlew test` — 488 tests across 74 classes, all green (JDK 21 toolchain).
- `InterpolatorTest.failsWhenValueFileCannotBeRead` covers the directory case.
- End-to-end via `installDist`, both with the variable pointing at a directory and unset.
