### PR TITLE
Accept standalone patch definition files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1163,8 +1163,8 @@ Supports the file formats:
 - JSON5
 - Yaml
 - TOML, but processed output is not pretty
-      FILE_OR_DIR   Path to a PatchSet json file or directory containing
-                      PatchDefinition json files
+      FILE_OR_DIR   Path to a PatchSet or PatchDefinition json file, or
+                      directory containing PatchDefinition json files
   -h, --help        Show this usage and exit
       --json-allow-comments
                     Whether to allow comments in JSON files. Env:

--- a/src/main/java/me/itzg/helpers/patch/PatchCommand.java
+++ b/src/main/java/me/itzg/helpers/patch/PatchCommand.java
@@ -1,11 +1,13 @@
 package me.itzg.helpers.patch;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.env.Interpolator;
@@ -45,7 +47,7 @@ public class PatchCommand implements Callable<Integer> {
     )
     boolean jsonAllowComments;
 
-    @Parameters(description = "Path to a PatchSet json file or directory containing PatchDefinition json files",
+    @Parameters(description = "Path to a PatchSet or PatchDefinition json file, or directory containing PatchDefinition json files",
         paramLabel = "FILE_OR_DIR"
     )
     Path patches;
@@ -78,7 +80,7 @@ public class PatchCommand implements Callable<Integer> {
     }
 
     /**
-     * Looking at {@link #patches}, loads {@link PatchDefinition}s from a directory or a @{link PatchSet} from a file.
+     * Looking at {@link #patches}, loads patch definitions from a directory or a patch definition or set from a file.
      */
     private PatchSet loadPatchSet() throws IOException {
         if (Files.isDirectory(patches)) {
@@ -101,7 +103,16 @@ public class PatchCommand implements Callable<Integer> {
             return patchSet;
         }
         else {
-            return setSource(patches, patchSetMapper.readValue(patches.toFile(), PatchSet.class));
+            final JsonNode root = patchSetMapper.readTree(patches.toFile());
+            if (root.has("patches")) {
+                return setSource(patches, patchSetMapper.treeToValue(root, PatchSet.class));
+            }
+
+            return new PatchSet()
+                .setPatches(List.of(
+                    patchSetMapper.treeToValue(root, PatchDefinition.class)
+                        .setSrc(patches)
+                ));
         }
     }
 

--- a/src/test/java/me/itzg/helpers/patch/PatchCommandTest.java
+++ b/src/test/java/me/itzg/helpers/patch/PatchCommandTest.java
@@ -1,0 +1,49 @@
+package me.itzg.helpers.patch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.webcompere.modelassert.json.JsonAssertions.assertJson;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PatchCommandTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void loadsPatchDefinitionOrPatchSetFile(boolean wrapInPatchSet, @TempDir Path tempDir)
+            throws Exception {
+        final Path target = tempDir.resolve("target.json");
+        Files.writeString(target, "{\"name\":\"before\"}");
+
+        final ObjectNode definition = objectMapper.createObjectNode();
+        definition.put("file", target.toString());
+        definition.putArray("ops")
+            .addObject()
+            .putObject("$set")
+            .put("path", "$.name")
+            .put("value", "after");
+
+        final JsonNode input = wrapInPatchSet
+            ? objectMapper.createObjectNode()
+                .set("patches", objectMapper.createArrayNode().add(definition))
+            : definition;
+        final Path patchFile = tempDir.resolve("patch.json");
+        objectMapper.writeValue(patchFile.toFile(), input);
+
+        final PatchCommand command = new PatchCommand();
+        command.envPrefix = "CFG_";
+        command.jsonAllowComments = true;
+        command.patches = patchFile;
+
+        assertThat(command.call()).isZero();
+        assertJson(target).at("/name").hasValue("after");
+    }
+}


### PR DESCRIPTION
Detect whether a JSON file contains a PatchSet or a single PatchDefinition. Existing PatchSet and directory handling stays unchanged.

Tests: `./gradlew check --no-problems-report`

Closes #827