### PR TITLE
cf: load CurseForge API key from file env

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
+++ b/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
@@ -1,5 +1,9 @@
 package me.itzg.helpers.curseforge;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.InvalidParameterException;
@@ -46,9 +50,32 @@ public class ApiKeyHelper {
      * @throws InvalidParameterException if no API key is provided or cannot be loaded
      */
     public static String loadApiKey(String providedApiKey) {
+        return loadApiKey(providedApiKey, System.getenv());
+    }
+
+    static String loadApiKey(String providedApiKey, Map<String, String> environment) {
         if (providedApiKey != null && !providedApiKey.isBlank()) {
             log.debug("Using provided CurseForge API key");
             return providedApiKey.trim();
+        }
+
+        final String apiKeyFile = environment.get(CurseForgeApiClient.API_KEY_FILE_VAR);
+        if (apiKeyFile != null && !apiKeyFile.isBlank()) {
+            final String loadedApiKey;
+            try {
+                loadedApiKey = Files.readString(Path.of(apiKeyFile), StandardCharsets.UTF_8).trim();
+            } catch (IOException | RuntimeException e) {
+                throw new InvalidParameterException(
+                    "Unable to read CurseForge API key from " + CurseForgeApiClient.API_KEY_FILE_VAR, e, true
+                );
+            }
+            if (loadedApiKey.isBlank()) {
+                throw new InvalidParameterException(
+                    "CurseForge API key file from " + CurseForgeApiClient.API_KEY_FILE_VAR + " is empty"
+                );
+            }
+            log.debug("Loaded CurseForge API key from {}", CurseForgeApiClient.API_KEY_FILE_VAR);
+            return loadedApiKey;
         }
 
         // properties file and property need to match the ObbyTask in build.gradle

--- a/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
+++ b/src/main/java/me/itzg/helpers/curseforge/ApiKeyHelper.java
@@ -50,31 +50,30 @@ public class ApiKeyHelper {
      * @throws InvalidParameterException if no API key is provided or cannot be loaded
      */
     public static String loadApiKey(String providedApiKey) {
-        return loadApiKey(providedApiKey, System.getenv());
+        return loadApiKey(providedApiKey, null);
     }
 
-    static String loadApiKey(String providedApiKey, Map<String, String> environment) {
+    public static String loadApiKey(String providedApiKey, Path apiKeyFile) {
         if (providedApiKey != null && !providedApiKey.isBlank()) {
             log.debug("Using provided CurseForge API key");
             return providedApiKey.trim();
         }
 
-        final String apiKeyFile = environment.get(CurseForgeApiClient.API_KEY_FILE_VAR);
-        if (apiKeyFile != null && !apiKeyFile.isBlank()) {
+        if (apiKeyFile != null) {
             final String loadedApiKey;
             try {
-                loadedApiKey = Files.readString(Path.of(apiKeyFile), StandardCharsets.UTF_8).trim();
+                loadedApiKey = Files.readString(apiKeyFile, StandardCharsets.UTF_8).trim();
             } catch (IOException | RuntimeException e) {
                 throw new InvalidParameterException(
-                    "Unable to read CurseForge API key from " + CurseForgeApiClient.API_KEY_FILE_VAR, e, true
+                    "Unable to read CurseForge API key file " + apiKeyFile, e, true
                 );
             }
             if (loadedApiKey.isBlank()) {
                 throw new InvalidParameterException(
-                    "CurseForge API key file from " + CurseForgeApiClient.API_KEY_FILE_VAR + " is empty"
+                    "CurseForge API key file " + apiKeyFile + " is empty"
                 );
             }
-            log.debug("Loaded CurseForge API key from {}", CurseForgeApiClient.API_KEY_FILE_VAR);
+            log.debug("Loaded CurseForge API key from file");
             return loadedApiKey;
         }
 

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
@@ -51,6 +51,7 @@ public class CurseForgeApiClient implements AutoCloseable {
     public static final String CATEGORY_BUKKIT_PLUGINS = "bukkit-plugins";
     public static final String CATEGORY_WORLDS = "worlds";
     public static final String API_KEY_VAR = "CF_API_KEY";
+    public static final String API_KEY_FILE_VAR = API_KEY_VAR + "_FILE";
     public static final String ETERNAL_DEVELOPER_CONSOLE_URL = "https://console.curseforge.com/";
 
     private static final String API_KEY_HEADER = "x-api-key";

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeFilesCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeFilesCommand.java
@@ -79,6 +79,11 @@ public class CurseForgeFilesCommand implements Callable<Integer> {
     )
     String apiKey;
 
+    @Option(names = "--api-key-file", paramLabel = "PATH", defaultValue = "${env:CF_API_KEY_FILE}",
+        description = "Read the API key from a UTF-8 file (instead of passing it directly)."
+            + "%nCan also be passed via CF_API_KEY_FILE")
+    Path apiKeyFile;
+
     @Option(names = "--game-version", defaultValue = "${env:VERSION}",
         description = "The Minecraft version"
             + "%nCan also be passed via VERSION"
@@ -130,7 +135,7 @@ public class CurseForgeFilesCommand implements Callable<Integer> {
                         .setCacheDurations(CurseForgeApiClient.getCacheDurations());
                 final CurseForgeApiClient apiClient = new CurseForgeApiClient(
                     apiBaseUrl,
-                    loadApiKey(apiKey),
+                    loadApiKey(apiKey, apiKeyFile),
                     sharedFetchArgs.options(),
                     CurseForgeApiClient.MINECRAFT_GAME_ID,
                     apiCaching

--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeInstaller.java
@@ -96,6 +96,10 @@ public class CurseForgeInstaller {
 
     @Getter
     @Setter
+    private Path apiKeyFile;
+
+    @Getter
+    @Setter
     private boolean forceSynchronize;
 
     @Getter @Setter
@@ -219,7 +223,7 @@ public class CurseForgeInstaller {
                     .setCacheDurations(CurseForgeApiClient.getCacheDurations());
             final CurseForgeApiClient cfApi = new CurseForgeApiClient(
                 apiBaseUrl,
-                loadApiKey(apiKey),
+                loadApiKey(apiKey, apiKeyFile),
                 sharedFetchOptions,
                 CurseForgeApiClient.MINECRAFT_GAME_ID,
                 apiCaching

--- a/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
+++ b/src/main/java/me/itzg/helpers/curseforge/InstallCurseForgeCommand.java
@@ -89,6 +89,11 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
     )
     String apiKey;
 
+    @Option(names = "--api-key-file", paramLabel = "PATH", defaultValue = "${env:CF_API_KEY_FILE}",
+        description = "Read the API key from a UTF-8 file (instead of passing it directly)."
+            + "%nCan also be passed via CF_API_KEY_FILE")
+    Path apiKeyFile;
+
     @Option(names = "--mod-loader-version", paramLabel = "VERSION",
         description = "Override the mod loader version specified in the modpack"
     )
@@ -238,6 +243,7 @@ public class InstallCurseForgeCommand implements Callable<Integer> {
             .setOverridesExclusions(overridesExclusions)
             .setSharedFetchOptions(sharedFetchArgs.options())
             .setApiKey(apiKey)
+            .setApiKeyFile(apiKeyFile)
             .setDownloadsRepo(downloadsRepo)
             .setDisableApiCaching(disableApiCaching)
             .setCacheArgs(cacheArgs)

--- a/src/test/java/me/itzg/helpers/curseforge/ApiKeyHelperTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/ApiKeyHelperTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import me.itzg.helpers.errors.InvalidParameterException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -16,10 +15,10 @@ class ApiKeyHelperTest {
     Path tempDir;
 
     @Test
-    void loadsApiKeyFromFileEnvironmentVariable() throws Exception {
+    void loadsApiKeyFromFile() throws Exception {
         final Path apiKeyFile = Files.writeString(tempDir.resolve("cf-api-key"), "key-from-file\n");
 
-        assertThat(ApiKeyHelper.loadApiKey(null, Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, apiKeyFile.toString())))
+        assertThat(ApiKeyHelper.loadApiKey(null, apiKeyFile))
             .isEqualTo("key-from-file");
     }
 
@@ -27,7 +26,7 @@ class ApiKeyHelperTest {
     void providedApiKeyTakesPrecedenceOverFileEnvironmentVariable() throws Exception {
         final Path apiKeyFile = Files.writeString(tempDir.resolve("cf-api-key"), "key-from-file\n");
 
-        assertThat(ApiKeyHelper.loadApiKey("provided", Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, apiKeyFile.toString())))
+        assertThat(ApiKeyHelper.loadApiKey("provided", apiKeyFile))
             .isEqualTo("provided");
     }
 
@@ -35,9 +34,8 @@ class ApiKeyHelperTest {
     void unreadableApiKeyFileIsAConfigurationError() {
         final Path missingFile = tempDir.resolve("missing-cf-api-key");
 
-        assertThatThrownBy(() -> ApiKeyHelper.loadApiKey(
-            null, Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, missingFile.toString())))
+        assertThatThrownBy(() -> ApiKeyHelper.loadApiKey(null, missingFile))
             .isInstanceOf(InvalidParameterException.class)
-            .hasMessageContaining(CurseForgeApiClient.API_KEY_FILE_VAR);
+            .hasMessageContaining("CurseForge API key file");
     }
 }

--- a/src/test/java/me/itzg/helpers/curseforge/ApiKeyHelperTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/ApiKeyHelperTest.java
@@ -1,0 +1,43 @@
+package me.itzg.helpers.curseforge;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import me.itzg.helpers.errors.InvalidParameterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ApiKeyHelperTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void loadsApiKeyFromFileEnvironmentVariable() throws Exception {
+        final Path apiKeyFile = Files.writeString(tempDir.resolve("cf-api-key"), "key-from-file\n");
+
+        assertThat(ApiKeyHelper.loadApiKey(null, Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, apiKeyFile.toString())))
+            .isEqualTo("key-from-file");
+    }
+
+    @Test
+    void providedApiKeyTakesPrecedenceOverFileEnvironmentVariable() throws Exception {
+        final Path apiKeyFile = Files.writeString(tempDir.resolve("cf-api-key"), "key-from-file\n");
+
+        assertThat(ApiKeyHelper.loadApiKey("provided", Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, apiKeyFile.toString())))
+            .isEqualTo("provided");
+    }
+
+    @Test
+    void unreadableApiKeyFileIsAConfigurationError() {
+        final Path missingFile = tempDir.resolve("missing-cf-api-key");
+
+        assertThatThrownBy(() -> ApiKeyHelper.loadApiKey(
+            null, Map.of(CurseForgeApiClient.API_KEY_FILE_VAR, missingFile.toString())))
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining(CurseForgeApiClient.API_KEY_FILE_VAR);
+    }
+}


### PR DESCRIPTION
## Summary

Load the CurseForge API key directly from the conventional CF_API_KEY_FILE environment variable.

## Details

- Added CF_API_KEY_FILE alongside the existing CF_API_KEY constant
- Preserve explicit --api-key precedence
- Read the file as UTF-8 and trim the trailing newline commonly present in mounted secrets
- Treat missing, unreadable, or empty files as configuration errors without logging the secret
- Added focused tests for file loading, precedence, and missing-file handling

## Validation

- ./gradlew test --tests 'me.itzg.helpers.curseforge.*'`n- git diff --check`n
Closes #829