### PR TITLE
patch: support properties files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Commands:
                                   - JSON5
                                   - Yaml
                                   - TOML, but processed output is not pretty
+                                  - Properties, but comments are not retained
   resolve-minecraft-version       Resolves and validate latest, snapshot, and
                                     specific versions
   set-properties                  Maps environment variables to a properties
@@ -1163,6 +1164,7 @@ Supports the file formats:
 - JSON5
 - Yaml
 - TOML, but processed output is not pretty
+- Properties, but comments are not retained
       FILE_OR_DIR   Path to a PatchSet or PatchDefinition json file, or
                       directory containing PatchDefinition json files
   -h, --help        Show this usage and exit
@@ -1423,7 +1425,7 @@ Example
 ### PatchDefinition
 
 - `file` : Path to the file to patch
-- `file-format` : **optional** If non-null, declares a specifically supported format name: json, yaml. Otherwise, the file format is detected by the file's suffix.
+- `file-format` : **optional** If non-null, declares a specifically supported format name: json, json5, yaml, toml, properties. Otherwise, the file format is detected by the file's suffix.
 - `ops` : array of [PatchOperation](#patchoperation)
 
 Example:

--- a/src/main/java/me/itzg/helpers/patch/PatchCommand.java
+++ b/src/main/java/me/itzg/helpers/patch/PatchCommand.java
@@ -25,7 +25,8 @@ import picocli.CommandLine.Parameters;
         + "- JSON%n"
         + "- JSON5%n"
         + "- Yaml%n"
-        + "- TOML, but processed output is not pretty",
+        + "- TOML, but processed output is not pretty%n"
+        + "- Properties, but comments are not retained",
     showDefaultValues = true
 )
 @Slf4j

--- a/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
+++ b/src/main/java/me/itzg/helpers/patch/PatchSetProcessor.java
@@ -41,7 +41,8 @@ public class PatchSetProcessor {
                 new JsonFileFormat(jsonAllowComments),
                 new Json5FileFormat(),
                 new YamlFileFormat(),
-                new TomlFileFormat()
+                new TomlFileFormat(),
+                new PropertiesFileFormat()
         };
     }
 
@@ -78,12 +79,13 @@ public class PatchSetProcessor {
                             ), e, true);
                         }
 
+                        // encode before opening the file, since opening it truncates and a
+                        // failure to encode would otherwise leave nothing behind
+                        final byte[] encoded = fileFormat.encode(data)
+                            .getBytes(detected.getCharset());
+
                         try (OutputStream out = Files.newOutputStream(filePath)) {
-                            out.write(
-                                    fileFormat
-                                            .encode(data)
-                                            .getBytes(detected.getCharset())
-                            );
+                            out.write(encoded);
                         }
                     }
                 } catch (IOException e) {

--- a/src/main/java/me/itzg/helpers/patch/PropertiesFileFormat.java
+++ b/src/main/java/me/itzg/helpers/patch/PropertiesFileFormat.java
@@ -79,8 +79,15 @@ public class PropertiesFileFormat implements FileFormat {
         final StringWriter out = new StringWriter();
         properties.store(out, null);
 
-        // store() leads with the date, which java.properties.date can turn into several lines
-        final String written = out.toString();
+        return stripLeadingComments(out.toString());
+    }
+
+    /**
+     * {@link Properties#store} leads with the date, which the java.properties.date system
+     * property can turn into several lines. Lines are located by their newline, so this works
+     * whichever line separator {@link Properties#store} used.
+     */
+    static String stripLeadingComments(String written) {
         int start = 0;
         while (start < written.length()
             && (written.charAt(start) == '#' || written.charAt(start) == '!')) {

--- a/src/main/java/me/itzg/helpers/patch/PropertiesFileFormat.java
+++ b/src/main/java/me/itzg/helpers/patch/PropertiesFileFormat.java
@@ -1,0 +1,112 @@
+package me.itzg.helpers.patch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+
+/**
+ * Properties files are a flat namespace of string values, so the decoded model is a flat map
+ * of the keys exactly as they appear in the file. All escaping is delegated to
+ * {@link Properties}; the only thing added here is preserving the key order of the original
+ * file, which {@link Properties#store} would otherwise lose.
+ * <p>
+ * Comments are not retained, which matches the {@code set-properties} command.
+ */
+public class PropertiesFileFormat implements FileFormat {
+
+    private static final String[] SUFFIXES = {"properties"};
+
+    @Override
+    public String[] getFileSuffixes() {
+        return SUFFIXES;
+    }
+
+    @Override
+    public String getName() {
+        return "properties";
+    }
+
+    @Override
+    public Map<String, Object> decode(String content) throws IOException {
+        final Map<String, Object> ordered = new LinkedHashMap<>();
+        // that load() populates via put() is an implementation detail rather than a documented
+        // guarantee, so the sizes are compared below rather than trusting it
+        final Properties properties = new Properties() {
+            @Override
+            public synchronized Object put(Object key, Object value) {
+                ordered.put((String) key, value);
+                return super.put(key, value);
+            }
+        };
+        properties.load(new StringReader(content));
+
+        if (ordered.size() != properties.size()) {
+            throw GenericException.formatted(
+                "Read %d properties but only observed %d of them, so their order is unknown",
+                properties.size(), ordered.size()
+            );
+        }
+        return ordered;
+    }
+
+    @Override
+    public String encode(Map<String, Object> content) throws IOException {
+        content.forEach(PropertiesFileFormat::requireScalar);
+
+        // store() is specified to write "in the natural sort order of the keys in entrySet()
+        // unless entrySet() is overridden by a subclass", so an insertion ordered view of it
+        // retains the original key order while the escaping stays with Properties
+        final Properties properties = new Properties() {
+            @Override
+            public Set<Map.Entry<Object, Object>> entrySet() {
+                final Set<Map.Entry<Object, Object>> ordered = new LinkedHashSet<>();
+                content.forEach((key, value) ->
+                    ordered.add(new AbstractMap.SimpleEntry<>(key, String.valueOf(value))));
+                return ordered;
+            }
+        };
+
+        final StringWriter out = new StringWriter();
+        properties.store(out, null);
+
+        // store() leads with the date, which java.properties.date can turn into several lines
+        final String written = out.toString();
+        int start = 0;
+        while (start < written.length()
+            && (written.charAt(start) == '#' || written.charAt(start) == '!')) {
+            final int endOfLine = written.indexOf('\n', start);
+            if (endOfLine < 0) {
+                return "";
+            }
+            start = endOfLine + 1;
+        }
+        return written.substring(start);
+    }
+
+    private static void requireScalar(String key, Object value) {
+        final String kind;
+        if (value == null || (value instanceof JsonNode && ((JsonNode) value).isNull())) {
+            kind = "null";
+        } else if (value instanceof Map || value instanceof Collection
+            || (value instanceof JsonNode && ((JsonNode) value).isContainerNode())) {
+            kind = "structured";
+        } else {
+            return;
+        }
+
+        throw InvalidParameterException.formatted(
+            "Properties files can only hold scalar values, but a %s value was given for '%s'",
+            kind, key
+        );
+    }
+}

--- a/src/main/java/me/itzg/helpers/patch/model/PatchDefinition.java
+++ b/src/main/java/me/itzg/helpers/patch/model/PatchDefinition.java
@@ -14,8 +14,9 @@ public class PatchDefinition {
     @JsonPropertyDescription("Path to the file to patch")
     String file;
 
-    @JsonPropertyDescription("If non-null, declares a specifically supported format name: json, yaml. " +
-            "Otherwise, the file format is detected by the file's suffix.")
+    @JsonPropertyDescription("If non-null, declares a specifically supported format name: "
+            + "json, json5, yaml, toml, properties. "
+            + "Otherwise, the file format is detected by the file's suffix.")
     @JsonProperty("file-format")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String fileFormat;

--- a/src/test/java/me/itzg/helpers/patch/PatchSetProcessorTest.java
+++ b/src/test/java/me/itzg/helpers/patch/PatchSetProcessorTest.java
@@ -325,6 +325,66 @@ class PatchSetProcessorTest {
     }
 
     @Test
+    void setInProperties(@TempDir Path tempDir) throws IOException {
+        final Path src = tempDir.resolve("testing.properties");
+        Files.copy(Paths.get("src/test/resources/patch/testing.properties"), src);
+
+        final PatchSetProcessor processor = new PatchSetProcessor(
+                new Interpolator(environmentVariablesProvider, "CFG_")
+        );
+
+        processor.process(new PatchSet()
+                .setPatches(singletonList(
+                    new PatchDefinition()
+                        .setFile(src.toString())
+                        .setOps(Arrays.asList(
+                            new PatchSetOperation()
+                                .setPath("$.second")
+                                .setValue(new TextNode("changed")),
+                            // a key containing a dot needs bracket notation
+                            new PatchSetOperation()
+                                .setPath("$['with.dot']")
+                                .setValue(new IntNode(5))
+                        ))
+                ))
+        );
+
+        assertThat(src).hasSameTextualContentAs(
+                Paths.get("src/test/resources/patch/expected-setInProperties.properties")
+        );
+    }
+
+    @Test
+    void leavesFileAloneWhenItCannotBeEncoded(@TempDir Path tempDir) throws IOException {
+        final Path src = tempDir.resolve("testing.properties");
+        Files.copy(Paths.get("src/test/resources/patch/testing.properties"), src);
+
+        final PatchSetProcessor processor = new PatchSetProcessor(
+                new Interpolator(environmentVariablesProvider, "CFG_")
+        );
+
+        assertThatThrownBy(() ->
+            processor.process(new PatchSet()
+                    .setPatches(singletonList(
+                        new PatchDefinition()
+                            .setFile(src.toString())
+                            .setOps(singletonList(
+                                new PatchSetOperation()
+                                    .setPath("$.second")
+                                    .setValue(new TextNode("a,b"))
+                                    .setValueType("list of string")
+                            ))
+                    ))
+            )
+        )
+            .isInstanceOf(InvalidParameterException.class);
+
+        assertThat(src).hasSameTextualContentAs(
+                Paths.get("src/test/resources/patch/testing.properties")
+        );
+    }
+
+    @Test
     void setNativeTypes(@TempDir Path tempDir) throws IOException {
         final Path src = tempDir.resolve("testing.yaml");
         Files.copy(Paths.get("src/test/resources/patch/testing.yaml"), src);

--- a/src/test/java/me/itzg/helpers/patch/PropertiesFileFormatTest.java
+++ b/src/test/java/me/itzg/helpers/patch/PropertiesFileFormatTest.java
@@ -1,0 +1,123 @@
+package me.itzg.helpers.patch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+import me.itzg.helpers.errors.InvalidParameterException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PropertiesFileFormatTest {
+
+    private final PropertiesFileFormat format = new PropertiesFileFormat();
+
+    public static Stream<Arguments> awkwardEntries() {
+        return Stream.of(
+            arguments("plain", "a", "b"),
+            arguments("empty value", "a", ""),
+            arguments("equals in value", "a", "x=y"),
+            arguments("colon in value", "a", "host:24454"),
+            arguments("hash in value", "a", "#not a comment"),
+            arguments("exclamation in value", "a", "!not a comment"),
+            arguments("backslash in value", "a", "C:\\path\\to"),
+            arguments("newline in value", "a", "line1\nline2"),
+            arguments("carriage return in value", "a", "line1\rline2"),
+            arguments("tab in value", "a", "col1\tcol2"),
+            arguments("leading space in value", "a", "   padded"),
+            arguments("trailing space in value", "a", "padded   "),
+            arguments("latin-1 in value", "a", "\u00A7cRed"),
+            arguments("multi-byte in value", "a", "\u4e2d\u6587"),
+            arguments("supplementary plane in value", "a", "\uD83D\uDE00 ok"),
+            arguments("control character in value", "a", "x\u0001y"),
+            arguments("equals in key", "a=b", "v"),
+            arguments("colon in key", "a:b", "v"),
+            arguments("space in key", "a b", "v"),
+            arguments("hash in key", "#a", "v"),
+            arguments("dot in key", "query.port", "25565"),
+            arguments("hyphen in key", "max-players", "20"),
+            arguments("backslash in key", "a\\b", "v"),
+            arguments("multi-byte in key", "\u4e2d\u6587", "v")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("awkwardEntries")
+    void roundTrips(String label, String key, String value) throws IOException {
+        final Map<String, Object> original = Collections.singletonMap(key, value);
+
+        final String encoded = format.encode(original);
+
+        assertThat(format.decode(encoded))
+            .as("encoded as:%n%s", encoded)
+            .containsExactlyEntriesOf(original);
+        assertThat(format.encode(format.decode(encoded)))
+            .as("encoding is stable")
+            .isEqualTo(encoded);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("awkwardEntries")
+    void readsWhatPropertiesItselfWrites(String label, String key, String value) throws IOException {
+        final Properties properties = new Properties();
+        properties.setProperty(key, value);
+        final StringWriter written = new StringWriter();
+        properties.store(written, null);
+
+        assertThat(format.decode(written.toString())).containsEntry(key, value);
+    }
+
+    @Test
+    void retainsKeyOrder() throws IOException {
+        final Map<String, Object> original = new LinkedHashMap<>();
+        original.put("zz", "1");
+        original.put("aa", "2");
+        original.put("mm", "3");
+
+        // store() separates entries with the platform line separator
+        final String eol = System.lineSeparator();
+        assertThat(format.encode(original)).isEqualTo("zz=1" + eol + "aa=2" + eol + "mm=3" + eol);
+    }
+
+    public static Stream<Arguments> unsupportedValues() {
+        final ObjectNode object = JsonNodeFactory.instance.objectNode();
+        object.put("k", "v");
+        final ArrayNode array = JsonNodeFactory.instance.arrayNode();
+        array.add(1);
+
+        return Stream.of(
+            arguments("json object", object, "structured"),
+            arguments("json array", array, "structured"),
+            arguments("java list", Arrays.asList(1, 2), "structured"),
+            arguments("java map", Collections.singletonMap("k", "v"), "structured"),
+            arguments("json null", NullNode.getInstance(), "null"),
+            arguments("java null", null, "null")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedValues")
+    void rejectsNonScalarValues(String label, Object value, String expectedKind) {
+        final Map<String, Object> content = new LinkedHashMap<>();
+        content.put("the-key", value);
+
+        assertThatThrownBy(() -> format.encode(content))
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining(expectedKind)
+            .hasMessageContaining("the-key");
+    }
+}

--- a/src/test/java/me/itzg/helpers/patch/PropertiesFileFormatTest.java
+++ b/src/test/java/me/itzg/helpers/patch/PropertiesFileFormatTest.java
@@ -88,9 +88,27 @@ class PropertiesFileFormatTest {
         original.put("aa", "2");
         original.put("mm", "3");
 
-        // store() separates entries with the platform line separator
-        final String eol = System.lineSeparator();
-        assertThat(format.encode(original)).isEqualTo("zz=1" + eol + "aa=2" + eol + "mm=3" + eol);
+        assertThat(format.encode(original))
+            .isEqualToNormalizingNewlines("zz=1\naa=2\nmm=3\n");
+    }
+
+    public static Stream<Arguments> leadingComments() {
+        return Stream.of(
+            arguments("one line, lf", "#date\na=b\n", "a=b\n"),
+            arguments("one line, crlf", "#date\r\na=b\r\n", "a=b\r\n"),
+            arguments("several lines, lf", "#one\n#two\na=b\n", "a=b\n"),
+            arguments("several lines, crlf", "#one\r\n#two\r\na=b\r\n", "a=b\r\n"),
+            arguments("written with an exclamation", "!date\r\na=b\r\n", "a=b\r\n"),
+            arguments("no entries follow", "#date\r\n", ""),
+            arguments("unterminated", "#date", ""),
+            arguments("an escaped hash never leads a line", "\\#a=b\r\n", "\\#a=b\r\n")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("leadingComments")
+    void stripsTheDateComment(String label, String written, String expected) {
+        assertThat(PropertiesFileFormat.stripLeadingComments(written)).isEqualTo(expected);
     }
 
     public static Stream<Arguments> unsupportedValues() {

--- a/src/test/resources/patch/expected-setInProperties.properties
+++ b/src/test/resources/patch/expected-setInProperties.properties
@@ -1,0 +1,5 @@
+first=1
+second=changed
+empty=
+with-hyphen=3
+with.dot=5

--- a/src/test/resources/patch/testing.properties
+++ b/src/test/resources/patch/testing.properties
@@ -1,0 +1,7 @@
+# a comment, which properties files cannot retain
+first=1
+# another comment
+second=two
+empty=
+with-hyphen=3
+with.dot=4


### PR DESCRIPTION
`patch` has no properties format, so a definition pointed at a `.properties` file is skipped with a warning and exit 0. This is the change I mentioned on #837. The case I ran into is a mod's own config — Simple Voice Chat's `voicechat-server.properties` — which `set-properties` does not cover, since that one is driven by `server.properties` definitions.

The model is flat and both directions go through `java.util.Properties`, the same pair `SetPropertiesCommand` already relies on, so no escaping is reimplemented here. Comments are not retained, as with `set-properties`. A value a properties file cannot hold — an object, an array, a `list of ...`, a null — now fails the patch with exit 2 rather than being written out as `list=[1, 2]`. That applies only to properties files; the other formats are unchanged.

One change lands outside the new format: `PatchSetProcessor` now encodes before opening the file, since `Files.newOutputStream` truncates on open and an exception out of `encode` used to leave a zero-byte file behind. Properties is the first format whose encode can fail, so this is latent today rather than something anyone can hit, but it belongs with the feature that makes it reachable.

<details><summary>Details, if useful</summary>

**Why the model is flat.** Keys are taken exactly as they appear in the file, with no dot-splitting into nested objects. `server.properties` carries `query.port` and `rcon.port` alongside plain keys, and splitting on dots would collide if a file ever held both `rcon` and `rcon.port`. A key containing a dot therefore needs bracket notation, `$['query.port']`, and getting that wrong is a hard failure rather than a silent miss. Hyphens are fine in plain dot notation, so `$.max-players` works.

**Key order** is retained from the original file, which `Properties.store` on its own does not do. That is the only thing added on top of the JDK.

**No warning for the lost comments.** Documenting it seemed better than a message on every patched file, and in the case that prompted this the mod rewrites its own comments from code on the next start.

**Docs.** The `patch` usage text and the `PatchDefinition.file-format` description are updated; the latter listed only "json, yaml", so it was already missing json5 and toml. I edited the affected lines of the generated README block by hand instead of regenerating it, because the committed block is about 486 lines out of sync with what the tool emits today and regenerating would bury this change in unrelated churn.

**Verified.**

- `./gradlew test` — 549 tests, all green, JDK 21 toolchain.
- `PropertiesFileFormatTest` round-trips 24 awkward entries in both directions: `=`, `:`, `#`, `!`, backslashes, newlines, tabs, leading and trailing spaces, control characters, empty values, latin-1, multi-byte and supplementary-plane characters, and the same set again in keys. Each is also read back from what `Properties.store` itself writes, so escaping parity with `set-properties` is pinned rather than assumed.
- Both new behaviours were checked red first: `setInProperties` fails if the format is not registered, and `leavesFileAloneWhenItCannotBeEncoded` fails if the encode-before-open reorder is reverted.
- End to end against the real Simple Voice Chat config: three ops applied with `value-type` `int`, `float` and `bool`; a `list of string` op rejected with exit 2 and the file left untouched, its 33 comment lines included.

</details>
