### PR TITLE
mcopy: 403 error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,8 @@ auto-detected sourcing from file list, directories, and URLs
       --ignore-missing-sources
                              Don't log or fail exit code when any or all
                                sources are missing
+      --max-concurrent-sources=<maxConccurentSources>
+                             Maximum number of sources to process concurrently
       --quiet-when-skipped   Don't log when file exists or is up to date
       --scope, --manifest-id=<manifestId>
                              If managed cleanup is required, this is the

--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,11 @@ auto-detected sourcing from file list, directories, and URLs
       --ignore-missing-sources
                              Don't log or fail exit code when any or all
                                sources are missing
+      --max-concurrent-sources=<maxConccurentSources>
+                             Maximum number of sources to process concurrently
+      --prefetch=<prefetch>  Number of results to request in advance from each
+                               active source
+
       --quiet-when-skipped   Don't log when file exists or is up to date
       --scope, --manifest-id=<manifestId>
                              If managed cleanup is required, this is the

--- a/README.md
+++ b/README.md
@@ -1060,11 +1060,6 @@ auto-detected sourcing from file list, directories, and URLs
       --ignore-missing-sources
                              Don't log or fail exit code when any or all
                                sources are missing
-      --max-concurrent-sources=<maxConccurentSources>
-                             Maximum number of sources to process concurrently
-      --prefetch=<prefetch>  Number of results to request in advance from each
-                               active source
-
       --quiet-when-skipped   Don't log when file exists or is up to date
       --scope, --manifest-id=<manifestId>
                              If managed cleanup is required, this is the

--- a/src/main/java/me/itzg/helpers/McImageHelper.java
+++ b/src/main/java/me/itzg/helpers/McImageHelper.java
@@ -45,7 +45,7 @@ import me.itzg.helpers.singles.HashCommand;
 import me.itzg.helpers.singles.NetworkInterfacesCommand;
 import me.itzg.helpers.singles.TestLoggingCommand;
 import me.itzg.helpers.sync.InterpolateCommand;
-import me.itzg.helpers.sync.MulitCopyCommand;
+import me.itzg.helpers.sync.MultiCopyCommand;
 import me.itzg.helpers.sync.Sync;
 import me.itzg.helpers.sync.SyncAndInterpolate;
 import me.itzg.helpers.users.ManageUsersCommand;
@@ -93,7 +93,7 @@ import picocli.CommandLine.Spec;
         ManageUsersCommand.class,
         MavenDownloadCommand.class,
         ModrinthCommand.class,
-        MulitCopyCommand.class,
+        MultiCopyCommand.class,
         NetworkInterfacesCommand.class,
         PatchCommand.class,
         ResolveMinecraftVersionCommand.class,

--- a/src/main/java/me/itzg/helpers/errors/ExceptionHandler.java
+++ b/src/main/java/me/itzg/helpers/errors/ExceptionHandler.java
@@ -1,6 +1,8 @@
 package me.itzg.helpers.errors;
 
 import java.time.Instant;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.McImageHelper;
 import me.itzg.helpers.http.FailedRequestException;
@@ -9,6 +11,7 @@ import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.IExecutionExceptionHandler;
 import picocli.CommandLine.IExitCodeExceptionMapper;
 import picocli.CommandLine.ParseResult;
+import reactor.core.Exceptions;
 
 @Slf4j
 public class ExceptionHandler implements IExecutionExceptionHandler {
@@ -31,6 +34,10 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
                     log.error("Invalid parameter provided for '{}' command: {}", commandLine.getCommandName(), e.getMessage());
                 }
                 log.debug("Invalid parameter details", e);
+            }
+            else if (Exceptions.isMultiple(e)) {
+                logCompositeExceptions(e, commandLine);
+                log.debug("Composite Exception details", e);
             }
             else if (e instanceof FailedRequestException) {
                 logExceptionWithoutStacktrace(e, commandLine);
@@ -67,5 +74,15 @@ public class ExceptionHandler implements IExecutionExceptionHandler {
             McImageHelper.getVersion(),
             ExceptionDetailer.buildCausalMessages(e)
         );
+    }
+
+    private static void logCompositeExceptions(Exception e, CommandLine commandLine) {
+        final String failures = Exceptions
+            .unwrapMultipleExcludingTracebacks(e)
+            .stream()
+            .map(ExceptionDetailer::buildCausalMessages)
+            .collect(Collectors.joining("; "));
+
+        log.error("'{}' command failed. Version is {}: {}", commandLine.getCommandName(), McImageHelper.getVersion(), failures);
     }
 }

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -41,7 +41,7 @@ import reactor.core.scheduler.Schedulers;
 @Command(name = "mcopy", description = "Multi-source file copy operation with with managed cleanup. "
     + "Supports auto-detected sourcing from file list, directories, and URLs")
 @Slf4j
-public class MulitCopyCommand implements Callable<Integer> {
+public class MultiCopyCommand implements Callable<Integer> {
     @SuppressWarnings("unused")
     @Option(names = {"--help", "-h"}, usageHelp = true)
     boolean showHelp;

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -100,7 +100,7 @@ public class MultiCopyCommand implements Callable<Integer> {
             final List<Path> results = Flux.fromIterable(sources)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .flatMap(source -> processSource(sharedFetch, source, fileIsListingOption, dest))
+                .concatMap(source -> processSource(sharedFetch, source, fileIsListingOption, dest))
                 .collectList()
                 .block();
 
@@ -185,7 +185,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                     final List<String> lines = Files.readAllLines(path);
                     return Flux.fromIterable(lines)
                         .filter(this::isListingLine)
-                        .flatMap(src -> processSource(sharedFetch, src,
+                        .concatMap(src -> processSource(sharedFetch, src,
                             // avoid recursive file-listing processing
                             false,
                             destination
@@ -326,7 +326,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .flatMapMany(content -> Flux.just(content.split("\\r?\\n")))
                     .filter(this::isListingLine)
             )
-            .flatMap(url -> processSource(sharedFetch, url, false, destination))
+            .concatMap(url -> processSource(sharedFetch, url, false, destination))
             .doOnTerminate(sharedFetch::close)
             .checkpoint("Processing remote listing at " + source, true);
     }

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -108,18 +108,15 @@ public class MultiCopyCommand implements Callable<Integer> {
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", sharedFetchArgs.options())) {
 
-
             final List<Path> results = Flux.fromIterable(sources)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .flatMapDelayError(
-                    source -> Flux.defer(() -> processSource(sharedFetch, source, fileIsListingOption, dest))
-                        .doOnError(error ->
-                            log.error("Failed to process source {}: {}", source, error.getMessage())
-                        ),
+                    source -> processSource(sharedFetch, source, fileIsListingOption, dest),
                     maxConccurentSources,
                     PREFETCH
                 )
+                .doOnError(error -> log.error("Failed to process source: {}", error.getMessage()))
                 .collectList()
                 .block();
 
@@ -205,16 +202,11 @@ public class MultiCopyCommand implements Callable<Integer> {
                     return Flux.fromIterable(lines)
                         .filter(this::isListingLine)
                         .flatMapDelayError(
-                            src -> Flux.defer(() -> processSource(sharedFetch, src,
-                                // avoid recursive file-listing processing
-                                false,
-                                destination
-                            )).doOnError(error ->
-                                log.error("Failed to process source {}: {}", src, error.getMessage())
-                            ),
+                            src -> processSource(sharedFetch, src, false, destination),
                             maxConccurentSources,
                             PREFETCH
-                        );
+                        )
+                        .doOnError(error -> log.error("Failed to process source: {}", error.getMessage()));
                 } catch (IOException e) {
                     return Mono.error(new GenericException("Failed to read file listing from " + path));
                 }
@@ -352,13 +344,11 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .filter(this::isListingLine)
             )
             .flatMapDelayError(
-                url -> Flux.defer(() -> processSource(sharedFetch, url, false, destination))
-                    .doOnError(error ->
-                        log.error("Failed to process source {}: {}", url, error.getMessage())
-                    ),
+                url -> processSource(sharedFetch, url, false, destination),
                 maxConccurentSources,
                 PREFETCH
             )
+            .doOnError(error -> log.error("Failed to process source: {}", error.getMessage()))
             .doOnTerminate(sharedFetch::close)
             .checkpoint("Processing remote listing at " + source, true);
     }

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -97,10 +97,19 @@ public class MultiCopyCommand implements Callable<Integer> {
     public Integer call() throws Exception {
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", sharedFetchArgs.options())) {
+
+
             final List<Path> results = Flux.fromIterable(sources)
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
-                .concatMap(source -> processSource(sharedFetch, source, fileIsListingOption, dest))
+                .flatMapDelayError(
+                    source -> Flux.defer(() -> processSource(sharedFetch, source, fileIsListingOption, dest))
+                        .doOnError(error ->
+                            log.error("Failed to process source {}: {}", source, error.getMessage())
+                        ),
+                    10, // maximum concurrent sources
+                    1   // prefetch
+                )
                 .collectList()
                 .block();
 
@@ -185,11 +194,17 @@ public class MultiCopyCommand implements Callable<Integer> {
                     final List<String> lines = Files.readAllLines(path);
                     return Flux.fromIterable(lines)
                         .filter(this::isListingLine)
-                        .concatMap(src -> processSource(sharedFetch, src,
-                            // avoid recursive file-listing processing
-                            false,
-                            destination
-                        ));
+                        .flatMapDelayError(
+                            src -> Flux.defer(() -> processSource(sharedFetch, src,
+                                // avoid recursive file-listing processing
+                                false,
+                                destination
+                            )).doOnError(error ->
+                                log.error("Failed to process source {}: {}", src, error.getMessage())
+                            ),
+                            10,
+                            1
+                        );
                 } catch (IOException e) {
                     return Mono.error(new GenericException("Failed to read file listing from " + path));
                 }
@@ -326,7 +341,14 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .flatMapMany(content -> Flux.just(content.split("\\r?\\n")))
                     .filter(this::isListingLine)
             )
-            .concatMap(url -> processSource(sharedFetch, url, false, destination))
+            .flatMapDelayError(
+                url -> Flux.defer(() -> processSource(sharedFetch, url, false, destination))
+                    .doOnError(error ->
+                        log.error("Failed to process source {}: {}", url, error.getMessage())
+                    ),
+                10,
+                1
+            )
             .doOnTerminate(sharedFetch::close)
             .checkpoint("Processing remote listing at " + source, true);
     }

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -80,12 +80,6 @@ public class MultiCopyCommand implements Callable<Integer> {
     @ArgGroup(exclusive = false)
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
-    @Option(names = "--max-concurrent-sources", defaultValue = "10", description = "Maximum number of sources to process concurrently")
-    int maxConccurentSources;
-
-    @Option(names = "--prefetch", defaultValue = "1", description = "Number of results to request in advance from each active source")
-    int prefetch;
-
     @Parameters(split = SPLIT_COMMA_NL, splitSynopsisLabel = SPLIT_SYNOPSIS_COMMA_NL,
         paramLabel = "SRC",
         description = "Any mix of source file, directory, or URLs delimited by commas or newlines"
@@ -99,16 +93,14 @@ public class MultiCopyCommand implements Callable<Integer> {
 
     private final static String destinationDelimiter = "<";
 
+    private final static int MAX_CONCURENT_SOURCES = 10;
+
+    private final static int PREFETCH = 1;
+
+
     @Override
     public Integer call() throws Exception {
 
-        if (maxConccurentSources <= 0) {
-            throw new InvalidParameterException("Max concurrent sources must be greater than 0");
-        }
-
-        if (prefetch <= 0) {
-            throw new InvalidParameterException("Prefetch must be greater than 0");
-        }
 
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", sharedFetchArgs.options())) {
@@ -122,8 +114,8 @@ public class MultiCopyCommand implements Callable<Integer> {
                         .doOnError(error ->
                             log.error("Failed to process source {}: {}", source, error.getMessage())
                         ),
-                    maxConccurentSources,
-                    prefetch
+                    MAX_CONCURENT_SOURCES,
+                    PREFETCH
                 )
                 .collectList()
                 .block();
@@ -217,8 +209,8 @@ public class MultiCopyCommand implements Callable<Integer> {
                             )).doOnError(error ->
                                 log.error("Failed to process source {}: {}", src, error.getMessage())
                             ),
-                            maxConccurentSources,
-                            prefetch
+                            MAX_CONCURENT_SOURCES,
+                            PREFETCH
                         );
                 } catch (IOException e) {
                     return Mono.error(new GenericException("Failed to read file listing from " + path));
@@ -361,8 +353,8 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .doOnError(error ->
                         log.error("Failed to process source {}: {}", url, error.getMessage())
                     ),
-                maxConccurentSources,
-                1
+                MAX_CONCURENT_SOURCES,
+                PREFETCH
             )
             .doOnTerminate(sharedFetch::close)
             .checkpoint("Processing remote listing at " + source, true);

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -93,15 +93,18 @@ public class MultiCopyCommand implements Callable<Integer> {
 
     private final static String destinationDelimiter = "<";
 
-    private final static int MAX_CONCURENT_SOURCES = 10;
-
     private final static int PREFETCH = 1;
+
+    @Option(names = "--max-concurrent-sources", defaultValue = "10", description = "Maximum number of sources to process concurrently")
+    int maxConccurentSources;
 
 
     @Override
     public Integer call() throws Exception {
 
-
+        if (maxConccurentSources <= 0) {
+            throw new InvalidParameterException("Max Concurrent sources must be greater than 0");
+        }
 
         try (SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", sharedFetchArgs.options())) {
 
@@ -114,7 +117,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                         .doOnError(error ->
                             log.error("Failed to process source {}: {}", source, error.getMessage())
                         ),
-                    MAX_CONCURENT_SOURCES,
+                    maxConccurentSources,
                     PREFETCH
                 )
                 .collectList()
@@ -209,7 +212,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                             )).doOnError(error ->
                                 log.error("Failed to process source {}: {}", src, error.getMessage())
                             ),
-                            MAX_CONCURENT_SOURCES,
+                            maxConccurentSources,
                             PREFETCH
                         );
                 } catch (IOException e) {
@@ -353,7 +356,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .doOnError(error ->
                         log.error("Failed to process source {}: {}", url, error.getMessage())
                     ),
-                MAX_CONCURENT_SOURCES,
+                maxConccurentSources,
                 PREFETCH
             )
             .doOnTerminate(sharedFetch::close)

--- a/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
+++ b/src/main/java/me/itzg/helpers/sync/MultiCopyCommand.java
@@ -80,6 +80,12 @@ public class MultiCopyCommand implements Callable<Integer> {
     @ArgGroup(exclusive = false)
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
+    @Option(names = "--max-concurrent-sources", defaultValue = "10", description = "Maximum number of sources to process concurrently")
+    int maxConccurentSources;
+
+    @Option(names = "--prefetch", defaultValue = "1", description = "Number of results to request in advance from each active source")
+    int prefetch;
+
     @Parameters(split = SPLIT_COMMA_NL, splitSynopsisLabel = SPLIT_SYNOPSIS_COMMA_NL,
         paramLabel = "SRC",
         description = "Any mix of source file, directory, or URLs delimited by commas or newlines"
@@ -96,6 +102,15 @@ public class MultiCopyCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
 
+        if (maxConccurentSources <= 0) {
+            throw new InvalidParameterException("Max concurrent sources must be greater than 0");
+        }
+
+        if (prefetch <= 0) {
+            throw new InvalidParameterException("Prefetch must be greater than 0");
+        }
+
+
         try (SharedFetch sharedFetch = Fetch.sharedFetch("mcopy", sharedFetchArgs.options())) {
 
 
@@ -107,8 +122,8 @@ public class MultiCopyCommand implements Callable<Integer> {
                         .doOnError(error ->
                             log.error("Failed to process source {}: {}", source, error.getMessage())
                         ),
-                    10, // maximum concurrent sources
-                    1   // prefetch
+                    maxConccurentSources,
+                    prefetch
                 )
                 .collectList()
                 .block();
@@ -202,8 +217,8 @@ public class MultiCopyCommand implements Callable<Integer> {
                             )).doOnError(error ->
                                 log.error("Failed to process source {}: {}", src, error.getMessage())
                             ),
-                            10,
-                            1
+                            maxConccurentSources,
+                            prefetch
                         );
                 } catch (IOException e) {
                     return Mono.error(new GenericException("Failed to read file listing from " + path));
@@ -346,7 +361,7 @@ public class MultiCopyCommand implements Callable<Integer> {
                     .doOnError(error ->
                         log.error("Failed to process source {}: {}", url, error.getMessage())
                     ),
-                10,
+                maxConccurentSources,
                 1
             )
             .doOnTerminate(sharedFetch::close)

--- a/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
+++ b/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
-class MulitCopyCommandTest {
+class MultiCopyCommandTest {
 
     private final RandomStringUtils randomStringUtils = RandomStringUtils.insecure();
     @TempDir
@@ -37,7 +37,7 @@ class MulitCopyCommandTest {
             final Path srcFile = writeLine(tempDir, "source.txt", "content");
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     srcFile.toString()
@@ -56,7 +56,7 @@ class MulitCopyCommandTest {
             final String manifestId = randomStringUtils.nextAlphabetic(10);
 
             {
-                final int exitCode = new CommandLine(new MulitCopyCommand())
+                final int exitCode = new CommandLine(new MultiCopyCommand())
                     .execute(
                         "--to", destDir.toString(),
                         "--manifest-id", manifestId,
@@ -72,7 +72,7 @@ class MulitCopyCommandTest {
             }
 
             {
-                final int exitCode = new CommandLine(new MulitCopyCommand())
+                final int exitCode = new CommandLine(new MultiCopyCommand())
                     .execute(
                         "--to", destDir.toString(),
                         "--manifest-id", manifestId
@@ -95,7 +95,7 @@ class MulitCopyCommandTest {
             final Path srcFile = writeLine(tempDir, "source2.txt", "content");
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "dest<" +srcFile.toString()
@@ -115,7 +115,7 @@ class MulitCopyCommandTest {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     String.join(",", srcTxt.toString(), srcJar.toString())
@@ -137,7 +137,7 @@ class MulitCopyCommandTest {
             final Path destDir1 = tempDir.resolve("dest1");
             final Path destDir2 = tempDir.resolve("dest2");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     String.join(",",
@@ -162,7 +162,7 @@ class MulitCopyCommandTest {
             final Path destDir1 = tempDir.resolve("dest1");
             final Path destDir2 = tempDir.resolve("dest2");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     String.join(",",
@@ -193,7 +193,7 @@ class MulitCopyCommandTest {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--file-is-listing",
@@ -221,7 +221,7 @@ class MulitCopyCommandTest {
                 "dest2<" + srcJar.toString()
             ));
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "--file-is-listing",
@@ -246,7 +246,7 @@ class MulitCopyCommandTest {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     srcDir.toString()
@@ -274,7 +274,7 @@ void recursiveDirectoryCopy() throws IOException {
 
     Path destDir = tempDir.resolve("dest");
 
-    int exitCode = new CommandLine(new MulitCopyCommand())
+    int exitCode = new CommandLine(new MultiCopyCommand())
             .execute(
                     "--to",
                     destDir.toString(),
@@ -301,7 +301,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "dest<" + srcDir
@@ -323,7 +323,7 @@ void recursiveDirectoryCopy() throws IOException {
             final Path destDir = tempDir.resolve("dest");
             final Path destTxt = destDir.resolve("one.txt");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     srcDir.toString()
@@ -339,7 +339,7 @@ void recursiveDirectoryCopy() throws IOException {
             writeLine(srcDir, "one.txt", "updated");
 
             assertThat(
-                new CommandLine(new MulitCopyCommand())
+                new CommandLine(new MultiCopyCommand())
                     .execute(
                         "--to", destDir.toString(),
                         srcDir.toString()
@@ -358,7 +358,7 @@ void recursiveDirectoryCopy() throws IOException {
             final Path destDir = tempDir.resolve("dest");
             final Path destTxt = destDir.resolve("one.txt");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--scope", "managedWithManifest",
@@ -373,7 +373,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             Files.delete(srcTxt);
             assertThat(
-                new CommandLine(new MulitCopyCommand())
+                new CommandLine(new MultiCopyCommand())
                     .execute(
                         "--to", destDir.toString(),
                         "--scope", "managedWithManifest",
@@ -396,7 +396,7 @@ void recursiveDirectoryCopy() throws IOException {
             final Path destTxt = destDir1.resolve("one.txt");
             final Path destJar = destDir2.resolve("two.jar");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "--scope", "managedWithManifest",
@@ -415,7 +415,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             Files.delete(srcTxt);
             assertThat(
-                new CommandLine(new MulitCopyCommand())
+                new CommandLine(new MultiCopyCommand())
                     .execute(
                         "--to", tempDir.toString(),
                         "--scope", "managedWithManifest",
@@ -437,7 +437,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--glob", "*.jar",
@@ -461,7 +461,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     wmInfo.getHttpBaseUrl() + "/file.jar"
@@ -478,7 +478,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "dest<" + wmInfo.getHttpBaseUrl() + "/file.jar"
@@ -501,7 +501,7 @@ void recursiveDirectoryCopy() throws IOException {
                 wmInfo.getHttpBaseUrl() + "/file2.jar"
             ));
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--file-is-listing",
@@ -528,7 +528,7 @@ void recursiveDirectoryCopy() throws IOException {
                 "dest2<" +wmInfo.getHttpBaseUrl() + "/file2.jar"
             ));
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "--file-is-listing",
@@ -553,7 +553,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--file-is-listing",
@@ -579,7 +579,7 @@ void recursiveDirectoryCopy() throws IOException {
             stubRemoteSrc("file1.jar", "one");
             stubRemoteSrc("file2.jar", "two");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "--file-is-listing",
@@ -606,7 +606,7 @@ void recursiveDirectoryCopy() throws IOException {
 
             final Path destDir = tempDir.resolve("dest");
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir.toString(),
                     "--file-is-listing",
@@ -634,7 +634,7 @@ void recursiveDirectoryCopy() throws IOException {
                     "dest2<" +  srcJar + "\n"
             );
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", tempDir.toString(),
                     "--file-is-listing",
@@ -665,7 +665,7 @@ void recursiveDirectoryCopy() throws IOException {
                     destDir3 + "<" +  srcYaml + "\n"
             );
 
-            final int exitCode = new CommandLine(new MulitCopyCommand())
+            final int exitCode = new CommandLine(new MultiCopyCommand())
                 .execute(
                     "--to", destDir1.toString(),
                     "--file-is-listing",

--- a/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
+++ b/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
@@ -13,7 +13,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
 import me.itzg.helpers.files.Manifests;
+import me.itzg.helpers.http.FailedRequestException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -487,6 +489,32 @@ void recursiveDirectoryCopy() throws IOException {
 
             assertThat(destDir.resolve("file.jar"))
                 .hasContent("remote");
+        }
+
+        @Test
+        void stopsAfterFirstRemoteFailure(WireMockRuntimeInfo wmInfo) {
+            stubFor(head(urlPathEqualTo("/first.jar"))
+                .willReturn(forbidden())
+            );
+            stubFor(head(urlPathEqualTo("/second.jar"))
+                .willReturn(forbidden())
+            );
+
+            final AtomicReference<Exception> executionException = new AtomicReference<>();
+            final int exitCode = new CommandLine(new MultiCopyCommand())
+                .setExecutionExceptionHandler((e, commandLine, parseResult) -> {
+                    executionException.set(e);
+                    return CommandLine.ExitCode.SOFTWARE;
+                })
+                .execute(
+                    "--to", tempDir.resolve("dest").toString(),
+                    wmInfo.getHttpBaseUrl() + "/first.jar," + wmInfo.getHttpBaseUrl() + "/second.jar"
+                );
+
+            assertThat(exitCode).isEqualTo(CommandLine.ExitCode.SOFTWARE);
+            assertThat(executionException.get()).isInstanceOf(FailedRequestException.class);
+            verify(1, headRequestedFor(urlPathEqualTo("/first.jar")));
+            verify(0, headRequestedFor(urlPathEqualTo("/second.jar")));
         }
 
         @Test

--- a/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
+++ b/src/test/java/me/itzg/helpers/sync/MultiCopyCommandTest.java
@@ -492,32 +492,6 @@ void recursiveDirectoryCopy() throws IOException {
         }
 
         @Test
-        void stopsAfterFirstRemoteFailure(WireMockRuntimeInfo wmInfo) {
-            stubFor(head(urlPathEqualTo("/first.jar"))
-                .willReturn(forbidden())
-            );
-            stubFor(head(urlPathEqualTo("/second.jar"))
-                .willReturn(forbidden())
-            );
-
-            final AtomicReference<Exception> executionException = new AtomicReference<>();
-            final int exitCode = new CommandLine(new MultiCopyCommand())
-                .setExecutionExceptionHandler((e, commandLine, parseResult) -> {
-                    executionException.set(e);
-                    return CommandLine.ExitCode.SOFTWARE;
-                })
-                .execute(
-                    "--to", tempDir.resolve("dest").toString(),
-                    wmInfo.getHttpBaseUrl() + "/first.jar," + wmInfo.getHttpBaseUrl() + "/second.jar"
-                );
-
-            assertThat(exitCode).isEqualTo(CommandLine.ExitCode.SOFTWARE);
-            assertThat(executionException.get()).isInstanceOf(FailedRequestException.class);
-            verify(1, headRequestedFor(urlPathEqualTo("/first.jar")));
-            verify(0, headRequestedFor(urlPathEqualTo("/second.jar")));
-        }
-
-        @Test
         void listingOfRemoteFiles(WireMockRuntimeInfo wmInfo) throws IOException {
             stubRemoteSrc("file1.jar", "one");
             stubRemoteSrc("file2.jar", "two");


### PR DESCRIPTION
fixes #319

#649 improved the primary `FailedRequestException` output by simplifying the logged error instead of full stack trace, however it didn't address the `onErrorDropped` issue

What happened in #319, when `MultiCopyCommand` is called, it takes a list of sources, in this case CurseForge URLs, and converts them into a Flux Stream.

A `flatMap` is then performed on that Flux Stream, which subscribes to multiple sources concurrently.

When one download returned a 403, the merged Flux propogated that error and cancelled the other running downloads. If another download during that time reported its own 403, Reactor couldn't deliver it to the subscriber, as they have already terminated, and instead it was routed to `onErrorDropped`, this is why in the issue we see the stack trace containing the response body, headers, etc logged. 

`flatMap` has been replaced with `concatMap` for source processing. `concatMap` subscribes to one source at a time, waits for it to complete before subscribing to the next. Errors are propagated immediately after each completion and later sources not started.

We could also use a `flatMapDelayError`, which would preserve parallel downloads while delaying error propagation until active sources complete, however i lean towards the fail-fast of `concatMap`

A test has been added which asserts that a second remote source is not requested after the first source fails.