### PR TITLE
modrinth: Add regex support for including/excluding resources

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
+++ b/src/main/java/me/itzg/helpers/curseforge/CurseForgeApiClient.java
@@ -27,6 +27,7 @@ import me.itzg.helpers.curseforge.model.ModsSearchResponse;
 import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidApiKeyException;
 import me.itzg.helpers.errors.RateLimitException;
+import me.itzg.helpers.files.MultiMatcher;
 import me.itzg.helpers.http.FailedRequestException;
 import me.itzg.helpers.http.Fetch;
 import me.itzg.helpers.http.FileDownloadStatusHandler;

--- a/src/main/java/me/itzg/helpers/files/MultiMatcher.java
+++ b/src/main/java/me/itzg/helpers/files/MultiMatcher.java
@@ -10,7 +10,7 @@ import me.itzg.helpers.errors.InvalidParameterException;
 /**
  * MultiMatcher matches using either a literal substring or a regex pattern.
  * 
- * <p> Patterns encolsed in forward slashes are evaluated as regex patterns
+ * <p> Patterns enclosed in forward slashes are evaluated as regex patterns
  * using {@link java.util.regex.Matcher#find()} other non-null patterns
  * are matched using {@link String#contains(CharSequence)}. A null pattern
  * matches every input

--- a/src/main/java/me/itzg/helpers/files/MultiMatcher.java
+++ b/src/main/java/me/itzg/helpers/files/MultiMatcher.java
@@ -7,6 +7,15 @@ import org.jspecify.annotations.Nullable;
 
 import me.itzg.helpers.errors.InvalidParameterException;
 
+/**
+ * MultiMatcher matches using either a literal substring or a regex pattern.
+ * 
+ * <p> Patterns encolsed in forward slashes are evaluated as regex patterns
+ * using {@link java.util.regex.Matcher#find()} other non-null patterns
+ * are matched using {@link String#contains(CharSequence)}. A null pattern
+ * matches every input
+ * 
+ */
 public class MultiMatcher {
 
     private final Pattern regex;

--- a/src/main/java/me/itzg/helpers/files/MultiMatcher.java
+++ b/src/main/java/me/itzg/helpers/files/MultiMatcher.java
@@ -1,4 +1,4 @@
-package me.itzg.helpers.curseforge;
+package me.itzg.helpers.files;
 
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;

--- a/src/main/java/me/itzg/helpers/modrinth/FileInclusionCalculator.java
+++ b/src/main/java/me/itzg/helpers/modrinth/FileInclusionCalculator.java
@@ -14,8 +14,8 @@ import me.itzg.helpers.modrinth.model.ModpackIndex;
 @Slf4j
 public class FileInclusionCalculator {
 
-    private final Set<MultiMatcher> excludeFiles;
-    private final Set<MultiMatcher> forceIncludeFiles;
+    private final List<MultiMatcher> excludeFiles;
+    private final List<MultiMatcher> forceIncludeFiles;
 
     public FileInclusionCalculator(
         String modpackProjectSlug,
@@ -95,10 +95,10 @@ public class FileInclusionCalculator {
         return exclude;
     }
 
-    private Set<MultiMatcher> createMatchers(Set<String> patterns) {
+    private List<MultiMatcher> createMatchers(Set<String> patterns) {
         return patterns.stream()
             .map(pattern -> new MultiMatcher(pattern.toLowerCase()))
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
     }
 
     static String sanitizeModFilePath(String path) {

--- a/src/main/java/me/itzg/helpers/modrinth/FileInclusionCalculator.java
+++ b/src/main/java/me/itzg/helpers/modrinth/FileInclusionCalculator.java
@@ -3,8 +3,10 @@ package me.itzg.helpers.modrinth;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.curseforge.ExcludeIncludesContent.ExcludeIncludes;
+import me.itzg.helpers.files.MultiMatcher;
 import me.itzg.helpers.modrinth.model.Env;
 import me.itzg.helpers.modrinth.model.EnvType;
 import me.itzg.helpers.modrinth.model.ModpackIndex;
@@ -12,8 +14,8 @@ import me.itzg.helpers.modrinth.model.ModpackIndex;
 @Slf4j
 public class FileInclusionCalculator {
 
-    private final Set<String> excludeFiles;
-    private final Set<String> forceIncludeFiles;
+    private final Set<MultiMatcher> excludeFiles;
+    private final Set<MultiMatcher> forceIncludeFiles;
 
     public FileInclusionCalculator(
         String modpackProjectSlug,
@@ -21,27 +23,30 @@ public class FileInclusionCalculator {
         List<String> forceIncludeFiles,
         ExcludeIncludesContent excludeIncludesContent) {
 
-        this.excludeFiles = new HashSet<>();
-        this.forceIncludeFiles = new HashSet<>();
+        final Set<String> excludePatterns = new HashSet<>();
+        final Set<String> forceIncludePatterns = new HashSet<>();
 
         if (excludeFiles != null) {
-            this.excludeFiles.addAll(excludeFiles);
+            excludePatterns.addAll(excludeFiles);
         }
         if (forceIncludeFiles != null) {
-            this.forceIncludeFiles.addAll(forceIncludeFiles);
+            forceIncludePatterns.addAll(forceIncludeFiles);
         }
         if (excludeIncludesContent != null) {
-            addAll(excludeIncludesContent.getGlobalExcludes(), this.excludeFiles);
-            addAll(excludeIncludesContent.getGlobalForceIncludes(), this.forceIncludeFiles);
+            addAll(excludeIncludesContent.getGlobalExcludes(), excludePatterns);
+            addAll(excludeIncludesContent.getGlobalForceIncludes(), forceIncludePatterns);
 
             if (excludeIncludesContent.getModpacks() != null && modpackProjectSlug != null) {
                 final ExcludeIncludes modpack = excludeIncludesContent.getModpacks().get(modpackProjectSlug);
                 if (modpack != null) {
-                    addAll(modpack.getExcludes(), this.excludeFiles);
-                    addAll(modpack.getForceIncludes(), this.forceIncludeFiles);
+                    addAll(modpack.getExcludes(), excludePatterns);
+                    addAll(modpack.getForceIncludes(), forceIncludePatterns);
                 }
             }
         }
+
+        this.excludeFiles = createMatchers(excludePatterns);
+        this.forceIncludeFiles = createMatchers(forceIncludePatterns);
     }
 
     public static FileInclusionCalculator empty() {
@@ -59,14 +64,14 @@ public class FileInclusionCalculator {
     }
 
     private boolean shouldForceIncludeFile(String modPath) {
-        if (forceIncludeFiles == null || forceIncludeFiles.isEmpty()) {
+        if (forceIncludeFiles.isEmpty()) {
             return false;
         }
 
         final String normalized = FileInclusionCalculator.sanitizeModFilePath(modPath).toLowerCase();
 
         final boolean include = forceIncludeFiles.stream()
-            .anyMatch(s -> normalized.contains(s.toLowerCase()));
+            .anyMatch(matcher -> matcher.matches(normalized));
         if (include) {
             log.debug("Force including '{}' as requested", modPath);
         }
@@ -75,7 +80,7 @@ public class FileInclusionCalculator {
     }
 
     private boolean shouldExcludeFile(String modPath) {
-        if (excludeFiles == null || excludeFiles.isEmpty()) {
+        if (excludeFiles.isEmpty()) {
             return false;
         }
 
@@ -83,13 +88,18 @@ public class FileInclusionCalculator {
         final String normalized = FileInclusionCalculator.sanitizeModFilePath(modPath).toLowerCase();
 
         final boolean exclude = excludeFiles.stream()
-            .anyMatch(s -> normalized.contains(s.toLowerCase()));
+            .anyMatch(matcher -> matcher.matches(normalized));
         if (exclude) {
             log.debug("Excluding '{}' as requested", modPath);
         }
         return exclude;
     }
 
+    private Set<MultiMatcher> createMatchers(Set<String> patterns) {
+        return patterns.stream()
+            .map(pattern -> new MultiMatcher(pattern.toLowerCase()))
+            .collect(Collectors.toSet());
+    }
 
     static String sanitizeModFilePath(String path) {
         // Using only backslash delimiters and not forward slashes?

--- a/src/main/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/InstallModrinthModpackCommand.java
@@ -92,7 +92,7 @@ public class InstallModrinthModpackCommand implements Callable<Integer> {
 
     @Option(names = "--exclude-files",
         split = McImageHelper.SPLIT_COMMA_NL, splitSynopsisLabel = McImageHelper.SPLIT_SYNOPSIS_COMMA_NL,
-        description = "Files to exclude, such as improperly declared client mods. It will match any part of the file's name/path."
+        description = "Files to exclude, such as improperly declared client mods. Plain values match any part of the file's name/path. Values surrounded by '/' are evaluated as Java regex patterns, E.G. '/(^|/)figura-/'"
             + "%nEmbedded comments are allowed."
     )
     public void setExcludeFiles(List<String> excludeFiles) {
@@ -102,7 +102,7 @@ public class InstallModrinthModpackCommand implements Callable<Integer> {
 
     @Option(names = "--force-include-files",
         split = McImageHelper.SPLIT_COMMA_NL, splitSynopsisLabel = McImageHelper.SPLIT_SYNOPSIS_COMMA_NL,
-        description = "Files to force include that were marked as non-server mods. It will match any part of the file's name/path."
+        description = "Files to force include that were marked as non-server mods. Plain values match any part of the file's name/path. Values surrounded by '/' are evaluated as Java regex patterns, E.G. '/(^|/)figura-/'"
             + "%nEmbedded comments are allowed."
     )
     public void setForceIncludeFiles(List<String> forceIncludeFiles) {

--- a/src/test/java/me/itzg/helpers/files/MultiMatcherTest.java
+++ b/src/test/java/me/itzg/helpers/files/MultiMatcherTest.java
@@ -1,4 +1,4 @@
-package me.itzg.helpers.curseforge;
+package me.itzg.helpers.files;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/me/itzg/helpers/modrinth/FileInclusionCalculatorTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/FileInclusionCalculatorTest.java
@@ -33,6 +33,27 @@ class FileInclusionCalculatorTest {
     }
 
     @Test
+    void regexExcludeDoesNotMatchSimilarFilename() {
+        final FileInclusionCalculator calculator = new FileInclusionCalculator(
+            null,
+            Collections.singletonList("/(^|/)figura-/"),
+            null,
+            null
+        );
+
+        final ModpackFile figura = new ModpackFile()
+            .setEnv(forServerAndClient())
+            .setPath("mods/figura-0.1.jar");
+
+        final ModpackFile configurable = new ModpackFile()
+            .setEnv(forServerAndClient())
+            .setPath("mods/configurable-3.5.2.jar");
+
+        assertThat(calculator.includeModFile(figura)).isFalse();
+        assertThat(calculator.includeModFile(configurable)).isTrue();
+    }
+
+    @Test
     void excludeForModpack() {
         final ExcludeIncludesContent globalContent = new ExcludeIncludesContent();
         globalContent.setGlobalExcludes(Collections.singleton("other"));


### PR DESCRIPTION
- Moved MultiMatcher to `me.itzg.helpers.files`
- `FileInclusionCalculator` now parses *excludeFiles* and *forceIncludeFiles* as *MultiMatcher* objects
- Added test excluding `figura` mod, asserting inclusion of `configurable` mod, emulating original false-positive error

After merging and updating `mc-image-helper` dependency in `docker-minecraft-server`, we can update the [Exclude/Include](https://github.com/itzg/docker-minecraft-server/blob/d62afadb5d174fdb1b66fb940e7b20cba9d93974/files/modrinth-exclude-include.json#L52) lists to replace the `figura` line with regex `/(^|/)figura-/` and remove `configurable` force-include, as well as updating [documentation](https://docker-minecraft-server.readthedocs.io/en/latest/types-and-platforms/mod-platforms/modrinth-modpacks/#default-excludeincludes)

refs: itzg/docker-minecraft-server#4234