### PR TITLE
fix: Version from modrinth command error handling and logging 

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ProjectRef.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ProjectRef.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import me.itzg.helpers.errors.InvalidParameterException;
@@ -20,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class ProjectRef {
     private static final Pattern VERSIONS = Pattern.compile("[a-zA-Z0-9]{8}");
     private static final Pattern MODPACK_PAGE_URL = Pattern.compile(

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -145,9 +145,67 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                         return version;
                     }
                 }
+    /**
+     * Build diagnostic message to describe failure to find compatbile release
+     *
+     * @param officialReleases Minecraft releases
+     * @param refs Required Modrinth projects
+     * @param versionMatrix List of versions supported per project
+     * @return a description of why no fully compatible release was found
+     */
+    private String describeNoCompatibleRelease(
+        List<VersionManifestV2.Version> officialReleases,
+        List<ProjectRef> refs,
+        Map<String, Set<Integer>> versionMatrix
+    ) {
+        int maxCoverage = 0;
+        final List<String> closestMatches = new ArrayList<>();
+
+        for (VersionManifestV2.Version release : officialReleases) {
+            final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
+            final int coverage = supportedProjects.size();
+            if (coverage > maxCoverage) {
+                maxCoverage = coverage;
+                closestMatches.clear();
+            }
+
+            if (coverage == maxCoverage && coverage > 0) {
+                final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
+
+                closestMatches.add(String.format(
+                    "  %s: %d/%d projects; missing: %s",
+                    release.getId(),
+                    coverage,
+                    refs.size(),
+                    String.join(", ", missingProjects)
+                ));
             }
         }
 
-        return null;
+        if (closestMatches.isEmpty()) {
+            return "Unable to find a compatible Minecraft release across given projects"
+                + "\nNo effective project supports an official release";
+        }
+
+        return "Unable to find a compatible Minecraft release across given projects"
+            + "\nClosest matches:\n"
+            + String.join("\n", closestMatches);
+    }
+
+    /**
+     * Finds the project names missing support for a Minecraft release.
+     *
+     * @param refs Required Modrinth projects
+     * @param supportedProjects the indexes of projects supporting the release
+     * @return Projects not in {@code supportedProjects}
+     */
+    private List<String> missingProjectNames(List<ProjectRef> refs, Set<Integer> supportedProjects) {
+        final List<String> missingProjects = new ArrayList<>();
+        for (int projectIndex = 0; projectIndex < refs.size(); projectIndex++) {
+            if (!supportedProjects.contains(projectIndex)) {
+                missingProjects.add(refs.get(projectIndex).getIdOrSlug());
+            }
+        }
+        return missingProjects;
     }
 }

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -59,13 +59,6 @@ import reactor.core.publisher.Mono;
 @Command(name = "version-from-modrinth-projects", description = "Finds a compatible Minecraft version across given Modrinth projects")
 @Slf4j
 public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
-    private URI minecraftManifestUrl;
-
-    VersionFromModrinthProjectsCommand setMinecraftManifestUrl(URI minecraftManifestUrl) {
-        this.minecraftManifestUrl = minecraftManifestUrl;
-        return this;
-    }
-
     @Option(
         names = "--projects",
         description = "Project ID or Slug. Can be <project ID>|<slug>,"
@@ -96,6 +89,11 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     )
     String baseUrl;
 
+    @Option(names = "--mc-api-base-url", defaultValue = "${env:MC_API_BASE_URL:-https://launchermeta.mojang.com/mc/game/version_manifest_v2.json}",
+    description = "Default: ${DEFAULT-VALUE}"
+    )
+    String mcBaseUrl;
+
     @ArgGroup(exclusive = false)
     SharedFetchArgs sharedFetchArgs = new SharedFetchArgs();
 
@@ -110,10 +108,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, "modrinth", sharedFetchArgs.options());
             SharedFetch minecraftVersionsFetch = new SharedFetch("minecraft-versions-api", sharedFetchArgs.options())
         ) {
-            final MinecraftVersionsApi minecraftVersionsApi = new MinecraftVersionsApi(minecraftVersionsFetch);
-            if (minecraftManifestUrl != null) {
-                minecraftVersionsApi.setManifestUrl(minecraftManifestUrl);
-            }
+            final MinecraftVersionsApi minecraftVersionsApi = new MinecraftVersionsApi(minecraftVersionsFetch).setManifestUrl(URI.create(mcBaseUrl));
 
             final String version = minecraftVersionsApi
                 .getAllReleases()

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -59,6 +59,12 @@ import reactor.core.publisher.Mono;
 @Command(name = "version-from-modrinth-projects", description = "Finds a compatible Minecraft version across given Modrinth projects")
 @Slf4j
 public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
+    private URI minecraftManifestUrl;
+
+    VersionFromModrinthProjectsCommand setMinecraftManifestUrl(URI minecraftManifestUrl) {
+        this.minecraftManifestUrl = minecraftManifestUrl;
+        return this;
+    }
 
     @Option(
         names = "--projects",
@@ -105,6 +111,9 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             SharedFetch minecraftVersionsFetch = new SharedFetch("minecraft-versions-api", sharedFetchArgs.options())
         ) {
             final MinecraftVersionsApi minecraftVersionsApi = new MinecraftVersionsApi(minecraftVersionsFetch);
+            if (minecraftManifestUrl != null) {
+                minecraftVersionsApi.setManifestUrl(minecraftManifestUrl);
+            }
 
             final String version = minecraftVersionsApi
                 .getAllReleases()

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -194,10 +194,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
      * @return Compatible Minecraft release if supported, or an empty result if no compatible release
      */
     private Mono<String> calculateVersion(List<VersionManifestV2.Version> officialReleases, List<ProjectRef> refs, List<List<String>> versions) {
-        final Map<String, Set<Integer>> versionMatrix = buildVersionMatrix(versions);
-        final String version = findHighestCompleteRelease(officialReleases, refs, versionMatrix);
-
-        return Mono.justOrEmpty(version);
+        return Mono.justOrEmpty(findHighestCompleteRelease(officialReleases, refs, versions));
     }
 
     /**
@@ -223,28 +220,6 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             });
     }
 
-
-    /**
-     * Builds matrix of releases against projects.
-     *
-     * @param versionMatrix List of versions supported per project
-     * @return Map of Minecraft releases against indexs of modrinth projects.
-     */
-    private Map<String, Set<Integer>> buildVersionMatrix(List<List<String>> versionMatrix) {
-        final Map<String, Set<Integer>> supportedByVersion = new HashMap<>();
-
-        for (int projectIndex = 0; projectIndex < versionMatrix.size(); projectIndex++) {
-            for (String gameVersion : new HashSet<>(versionMatrix.get(projectIndex))) {
-                supportedByVersion
-                    .computeIfAbsent(gameVersion, ignored -> new HashSet<>())
-                    .add(projectIndex);
-            }
-        }
-
-        return supportedByVersion;
-    }
-
-
     /**
      * Finds the first Minecraft release supported by all required projects.
      *
@@ -257,16 +232,16 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     private String findHighestCompleteRelease(
         List<VersionManifestV2.Version> officialReleases,
         List<ProjectRef> refs,
-        Map<String, Set<Integer>> versionMatrix
+        List<List<String>> versionsByProject
     ) {
         for (VersionManifestV2.Version release : officialReleases) {
-            final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
-            final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
+            final List<String> missingProjects = missingProjectNames(refs, versionsByProject, release.getId());
+            final int supportedProjectCount = refs.size() - missingProjects.size();
 
             if (missingProjects.isEmpty()) {
                 log.debug("{}: {}/{} projects",
                     release.getId(),
-                    supportedProjects.size(),
+                    supportedProjectCount,
                     refs.size()
                 );
 
@@ -275,7 +250,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
 
             log.debug("{}: {}/{} projects; missing: {}",
                 release.getId(),
-                supportedProjects.size(),
+                supportedProjectCount,
                 refs.size(),
                 String.join(", ", missingProjects)
             );
@@ -291,10 +266,14 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
      * @param supportedProjects the indexes of projects supporting the release
      * @return Projects not in {@code supportedProjects}
      */
-    private List<String> missingProjectNames(List<ProjectRef> refs, Set<Integer> supportedProjects) {
+    private static List<String> missingProjectNames(
+        List<ProjectRef> refs,
+        List<List<String>> versionsByProject,
+        String releaseId
+    ) {
         final List<String> missingProjects = new ArrayList<>();
         for (int projectIndex = 0; projectIndex < refs.size(); projectIndex++) {
-            if (!supportedProjects.contains(projectIndex)) {
+            if (!versionsByProject.get(projectIndex).contains(releaseId)) {
                 missingProjects.add(refs.get(projectIndex).getIdOrSlug());
             }
         }

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
@@ -138,9 +139,21 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
      * @return List of project references to use for version resolution.
      */
     private List<ProjectRef> parseProjects() {
+
+        if (projects == null || projects.isEmpty()) {
+            throw new InvalidParameterException("No Modrinth projects provided, please provide at least one Modrinth project");
+        }
+
         final List<ProjectRef> refs = projects.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(ref -> !ref.isEmpty())
             .map(ProjectRef::parse)
             .collect(Collectors.toList());
+
+        if (refs.isEmpty()) {
+            throw new InvalidParameterException("No Modrinth projects parsed successfully, please ensure projects follow \"<loader>:<project ID>|<slug>\" and are delimited by commas");
+        }
 
         final List<ProjectRef> requiredRefs = refs.stream()
             .filter(ref -> !ref.isOptional())

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -124,6 +124,10 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                 ))
                 .block();
 
+            if (version == null) {
+                return ExitCode.SOFTWARE;
+            }
+
             System.out.println(version);
             return ExitCode.OK;
         }
@@ -201,7 +205,9 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             return Mono.just(version);
         }
 
-        return Mono.error(new GenericException(describeNoCompatibleRelease(officialReleases, refs, versionMatrix)));
+        log.error(describeNoCompatibleRelease(officialReleases, refs, versionMatrix));
+
+        return Mono.empty();
     }
 
     /**

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -272,7 +272,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                 return release.getId();
             }
 
-            log.debug("Minecraft release {} rejected; missing support from: {}",
+            log.trace("Minecraft release {} rejected; missing support from: {}",
                 release.getId(), String.join(", ", missingProjects));
         }
 

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -149,8 +149,8 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             .filter(Objects::nonNull)
             .map(String::trim)
             .filter(ref -> !ref.isEmpty())
-            .distinct()
             .map(ProjectRef::parse)
+            .distinct()
             .collect(Collectors.toList());
 
         if (refs.isEmpty()) {

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -121,9 +121,6 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                     modrinthApiClient,
                     releases
                 ))
-                .doOnError(e -> {
-                    log.error("Failed to find a compatible release: {}", e.getMessage());
-                })
                 .block();
 
             System.out.println(version);

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -147,6 +147,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             .filter(Objects::nonNull)
             .map(String::trim)
             .filter(ref -> !ref.isEmpty())
+            .distinct()
             .map(ProjectRef::parse)
             .collect(Collectors.toList());
 

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -5,13 +5,8 @@ import static me.itzg.helpers.McImageHelper.SPLIT_SYNOPSIS_COMMA_NL;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -30,29 +25,34 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * Finds a compatible Minecraft release across a set of Modrinth projects.
+ * Finds the highest Minecraft release supported by all effective Modrinth
+ * project references.
  *
- * <p>Each project is resolved to the Minecraft game versions it supports. Those
- * versions are then compared with the official Minecraft release manifest. The
- * first release supported by every effective project reference is selected.
+ * <p>Each effective project reference is resolved to the Minecraft game versions
+ * it supports. Those versions are then compared with the official Minecraft
+ * release manifest. Releases are checked from newest to oldest, and the first
+ * release supported by every effective project reference is selected.
  *
- * <p>Project references are represented by their index in the input list when
- * constructing the support matrix. For example:
+ * <p>Each supported-version list remains aligned with its project reference by
+ * index:
  *
  * <pre>
- * Project A: 1.21.10, 1.21.9, 1.21.7
- * Project B: 1.21.10, 1.21.8, 1.21.7
- * Project C: 1.21.10, 1.21.7
- * Project D: 1.21.9, 1.21.7
+ * refs[0] = Project A
+ * versionsByProject[0] = [1.21.10, 1.21.9, 1.21.7]
  *
- * 1.21.10: 0, 1, 2
- * 1.21.9:  0, 3
- * 1.21.8:  1
- * 1.21.7:  0, 1, 2, 3
+ * refs[1] = Project B
+ * versionsByProject[1] = [1.21.10, 1.21.8, 1.21.7]
+ *
+ * refs[2] = Project C
+ * versionsByProject[2] = [1.21.10, 1.21.7]
+ *
+ * refs[3] = Project D
+ * versionsByProject[3] = [1.21.9, 1.21.7]
+ *
+ * Selected release: 1.21.7
  * </pre>
  *
- * <p>In this example, {@code 1.21.7} is supported by all four projects.
- * Optional project references are excluded from version resolution when at
+ * <p>Optional project references are excluded from version resolution when at
  * least one required reference is present. If all references are optional, all
  * references are used.
  */
@@ -129,13 +129,15 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     }
 
     /**
-     * Parse Modrinth Project References.
+     * Parses the configured Modrinth project references.
      *
-     * <p>Each configured value is parsed using {@link ProjectRef#parse(String)}.
-     * Required references are preferred over optional references. If every
-     * reference is optional, all references are used.
+     * <p>Null and blank values are ignored, non-blank values are trimmed, and
+     * duplicate values are removed before each remaining value is parsed using
+     * {@link ProjectRef#parse(String)}. Required references are preferred over
+     * optional references. If every reference is optional, all references are
+     * used.
      *
-     * @return List of project references to use for version resolution.
+     * @return the effective project references to use for version resolution
      */
     private List<ProjectRef> parseProjects() {
 
@@ -172,11 +174,12 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     }
 
     /**
-     * Resolves the Minecraft game versions supported by a Modrinth project.
-     *
+     * Resolves the Minecraft game versions supported by a Modrinth project
+     * reference.
+     *     
      * @param client Modrinth API client
-     * @param ref Modrinth project 
-     * @return List of supported Minecraft versions 
+     * @param ref Modrinth project reference
+     * @return a {@code Mono} emitting the supported Minecraft versions
      */
     private Mono<List<String>> resolveVersions(ModrinthApiClient client, ProjectRef ref) {
         final Loader loader = ref.getLoader() != null ? ref.getLoader() : this.loader;
@@ -186,23 +189,13 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     }
 
     /**
-     * Calculates the highest compatible Minecraft release across the projects.
-     *
-     * @param officialReleases Minecraft releases
-     * @param refs Required Modrinth projects
-     * @param versions List of supported Versions for each project
-     * @return Compatible Minecraft release if supported, or an empty result if no compatible release
-     */
-    private Mono<String> calculateVersion(List<VersionManifestV2.Version> officialReleases, List<ProjectRef> refs, List<List<String>> versions) {
-        return Mono.justOrEmpty(findHighestCompleteRelease(officialReleases, refs, versions));
-    }
-
-    /**
-     * Resolves project versions and calculates the highest compatible Minecraft release.
+     * Resolves supported game versions for each effective project reference and
+     * calculates the highest compatible Minecraft release.
      *
      * @param modrinthApiClient Modrinth API client
-     * @param officialReleases Minecraft releases
-     * @return Result containing compatible Minecraft release
+     * @param officialReleases Minecraft releases in newest to oldest order
+     * @return {@code Mono} emitting the compatible Minecraft version, or 
+     *                      empty if no compatible version exists
      */
     private Mono<String> versionFromProjects(
         ModrinthApiClient modrinthApiClient,
@@ -216,18 +209,22 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             })
             .collectList()
             .flatMap(allProjectVersions -> {
-                return calculateVersion(officialReleases, refs, allProjectVersions);
+                return Mono.justOrEmpty(findHighestCompleteRelease(officialReleases, refs, allProjectVersions));
             });
     }
 
     /**
-     * Finds the first Minecraft release supported by all required projects.
+     * Finds the highest Minecraft release supported by all effective project
+     * references.
      *
-     * @param officialReleases Minecraft releases
-     * @param refs Required Modrinth projects
-     * @param versionMatrix List of versions supported per project
-     * @return the compatible release ID, or {@code null} if no release is supported
-     *         by every project
+     * <p>The releases are traversed in the supplied order, so the list must be
+     * ordered from newest to oldest for the first matching release to be the
+     * highest compatible release.
+     *
+     * @param officialReleases Minecraft releases in newest-to-oldest order
+     * @param refs effective Modrinth project references
+     * @param versionsByProject one list of supported versions Minecraft per modrinth project reference
+     * @return Compatible minecraft version, or {@code null} if no releases is supported by all projects
      */
     private String findHighestCompleteRelease(
         List<VersionManifestV2.Version> officialReleases,
@@ -260,11 +257,12 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     }
 
     /**
-     * Finds the project names missing support for a Minecraft release.
+     * Finds the project identifiers missing support for a Minecraft release.
      *
-     * @param refs Required Modrinth projects
-     * @param supportedProjects the indexes of projects supporting the release
-     * @return Projects not in {@code supportedProjects}
+     * @param refs project references corresponding to {@code versionsByProject}
+     * @param versionsByProject one list of supported versions Minecraft per modrinth project reference
+     * @param releaseId Minecraft release ID to check
+     * @return Projects that do not support {@code releaseId}
      */
     private static List<String> missingProjectNames(
         List<ProjectRef> refs,

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -16,7 +16,6 @@ import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
-import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
@@ -125,6 +124,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                 .block();
 
             if (version == null) {
+                log.error("Failed to find a compatible Minecraft version across all projects");
                 return ExitCode.SOFTWARE;
             }
 
@@ -195,19 +195,13 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
      * @param officialReleases Minecraft releases
      * @param refs Required Modrinth projects
      * @param versions List of supported Versions for each project
-     * @return Compatbile Minecraft release if supported, or an error if no compatible release
+     * @return Compatible Minecraft release if supported, or an empty result if no compatible release
      */
     private Mono<String> calculateVersion(List<VersionManifestV2.Version> officialReleases, List<ProjectRef> refs, List<List<String>> versions) {
         final Map<String, Set<Integer>> versionMatrix = buildVersionMatrix(versions);
         final String version = findHighestCompleteRelease(officialReleases, refs, versionMatrix);
 
-        if (version != null) {
-            return Mono.just(version);
-        }
-
-        log.error(describeNoCompatibleRelease(officialReleases, refs, versionMatrix));
-
-        return Mono.empty();
+        return Mono.justOrEmpty(version);
     }
 
     /**
@@ -272,58 +266,20 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
         for (VersionManifestV2.Version release : officialReleases) {
             final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
             final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
+
+            log.debug("{}: {}/{} projects; missing: {}",
+                release.getId(),
+                supportedProjects.size(),
+                refs.size(),
+                String.join(", ", missingProjects)
+            );
+
             if (missingProjects.isEmpty()) {
-                log.debug("Minecraft release {} selected; supported by all {} effective projects",
-                    release.getId(), refs.size());
                 return release.getId();
             }
-
-            log.trace("Minecraft release {} rejected; missing support from: {}",
-                release.getId(), String.join(", ", missingProjects));
         }
 
         return null;
-    }
-
-
-    /**
-     * Build diagnostic message to describe failure to find compatbile release
-     *
-     * @param officialReleases Minecraft releases
-     * @param refs Required Modrinth projects
-     * @param versionMatrix List of versions supported per project
-     * @return a description of why no fully compatible release was found
-     */
-    private String describeNoCompatibleRelease(
-        List<VersionManifestV2.Version> officialReleases,
-        List<ProjectRef> refs,
-        Map<String, Set<Integer>> versionMatrix
-    ) {
-        final List<String> logs = new ArrayList<>();
-
-        for (VersionManifestV2.Version release : officialReleases) {
-            final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
-            final int coverage = supportedProjects.size();
-            final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
-
-                logs.add(String.format(
-                    "  %s: %d/%d projects; missing: %s",
-                    release.getId(),
-                    coverage,
-                    refs.size(),
-                    String.join(", ", missingProjects)
-                ));
-
-        }
-
-        if (logs.isEmpty()) {
-            return "Unable to find a compatible Minecraft release across given projects"
-                + "\nNo effective project supports an official release";
-        }
-
-        return "Unable to find a compatible Minecraft release across given projects"
-            + "\nClosest matches:\n"
-            + String.join("\n", logs);
     }
 
     /**

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -162,7 +162,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
         final List<ProjectRef> effectiveRefs;
 
         if (requiredRefs.isEmpty()) {
-            log.warn("All projects are marked as optional, using all for version resolution");
+            log.warn("All Modrinth projects are marked as optional, using all for version resolution");
             effectiveRefs = refs;
         } else {
             effectiveRefs = requiredRefs;

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -293,38 +293,31 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
         List<ProjectRef> refs,
         Map<String, Set<Integer>> versionMatrix
     ) {
-        int maxCoverage = 0;
-        final List<String> closestMatches = new ArrayList<>();
+        final List<String> logs = new ArrayList<>();
 
         for (VersionManifestV2.Version release : officialReleases) {
             final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
             final int coverage = supportedProjects.size();
-            if (coverage > maxCoverage) {
-                maxCoverage = coverage;
-                closestMatches.clear();
-            }
+            final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
 
-            if (coverage == maxCoverage && coverage > 0) {
-                final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
-
-                closestMatches.add(String.format(
+                logs.add(String.format(
                     "  %s: %d/%d projects; missing: %s",
                     release.getId(),
                     coverage,
                     refs.size(),
                     String.join(", ", missingProjects)
                 ));
-            }
+
         }
 
-        if (closestMatches.isEmpty()) {
+        if (logs.isEmpty()) {
             return "Unable to find a compatible Minecraft release across given projects"
                 + "\nNo effective project supports an official release";
         }
 
         return "Unable to find a compatible Minecraft release across given projects"
             + "\nClosest matches:\n"
-            + String.join("\n", closestMatches);
+            + String.join("\n", logs);
     }
 
     /**

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -267,16 +267,22 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
             final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
 
+            if (missingProjects.isEmpty()) {
+                log.debug("{}: {}/{} projects",
+                    release.getId(),
+                    supportedProjects.size(),
+                    refs.size()
+                );
+
+                return release.getId();
+            }
+
             log.debug("{}: {}/{} projects; missing: {}",
                 release.getId(),
                 supportedProjects.size(),
                 refs.size(),
                 String.join(", ", missingProjects)
             );
-
-            if (missingProjects.isEmpty()) {
-                return release.getId();
-            }
         }
 
         return null;

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -3,22 +3,59 @@ package me.itzg.helpers.modrinth;
 import static me.itzg.helpers.McImageHelper.SPLIT_COMMA_NL;
 import static me.itzg.helpers.McImageHelper.SPLIT_SYNOPSIS_COMMA_NL;
 
-import java.util.Arrays;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.http.SharedFetch;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.modrinth.model.VersionType;
+import me.itzg.helpers.versions.MinecraftVersionsApi;
+import me.itzg.helpers.versions.VersionManifestV2;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Option;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+/**
+ * Finds a compatible Minecraft release across a set of Modrinth projects.
+ *
+ * <p>Each project is resolved to the Minecraft game versions it supports. Those
+ * versions are then compared with the official Minecraft release manifest. The
+ * first release supported by every effective project reference is selected.
+ *
+ * <p>Project references are represented by their index in the input list when
+ * constructing the support matrix. For example:
+ *
+ * <pre>
+ * Project A: 1.21.10, 1.21.9, 1.21.7
+ * Project B: 1.21.10, 1.21.8, 1.21.7
+ * Project C: 1.21.10, 1.21.7
+ * Project D: 1.21.9, 1.21.7
+ *
+ * 1.21.10: 0, 1, 2
+ * 1.21.9:  0, 3
+ * 1.21.8:  1
+ * 1.21.7:  0, 1, 2, 3
+ * </pre>
+ *
+ * <p>In this example, {@code 1.21.7} is supported by all four projects.
+ * Optional project references are excluded from version resolution when at
+ * least one required reference is present. If all references are optional, all
+ * references are used.
+ */
 @Command(name = "version-from-modrinth-projects", description = "Finds a compatible Minecraft version across given Modrinth projects")
 @Slf4j
 public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
@@ -58,93 +95,172 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        try (ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, "modrinth", sharedFetchArgs.options())) {
-            final String version = versionFromProjects(modrinthApiClient, projects, loader, defaultVersionType);
 
-            if (version != null) {
-                System.out.println(version);
-                return ExitCode.OK;
-            }
-            else {
-                System.err.println("Unable to find a compatible Minecraft version across given projects");
-                return ExitCode.SOFTWARE;
-            }
+        if (projects == null || projects.isEmpty()) {
+            throw new InvalidParameterException("No projects provided, please provide at least one Modrinth project");
+        }
+
+        try (
+            ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, "modrinth", sharedFetchArgs.options());
+            SharedFetch minecraftVersionsFetch = new SharedFetch("minecraft-versions-api", sharedFetchArgs.options())
+        ) {
+            final MinecraftVersionsApi minecraftVersionsApi = new MinecraftVersionsApi(minecraftVersionsFetch);
+
+            final String version = minecraftVersionsApi
+                .getAllReleases()
+                .flatMap(releases -> versionFromProjects(
+                    modrinthApiClient,
+                    releases
+                ))
+                .doOnError(e -> {
+                    log.error("Failed to find a compatible release: {}", e.getMessage());
+                })
+                .block();
+
+            System.out.println(version);
+            return ExitCode.OK;
         }
     }
 
-    static String versionFromProjects(ModrinthApiClient modrinthApiClient, List<String> projectRefs, Loader defaultLoader, VersionType defaultVersionType) {
-        // Parse all refs and separate optional from required
-        final List<ProjectRef> allRefs = projectRefs.stream()
+    /**
+     * Parse Modrinth Project References.
+     *
+     * <p>Each configured value is parsed using {@link ProjectRef#parse(String)}.
+     * Required references are preferred over optional references. If every
+     * reference is optional, all references are used.
+     *
+     * @return List of project references to use for version resolution.
+     */
+    private List<ProjectRef> parseProjects() {
+        final List<ProjectRef> refs = projects.stream()
             .map(ProjectRef::parse)
             .collect(Collectors.toList());
 
-        final List<ProjectRef> requiredRefs = allRefs.stream()
+        final List<ProjectRef> requiredRefs = refs.stream()
             .filter(ref -> !ref.isOptional())
             .collect(Collectors.toList());
 
-        // Use required projects only for version resolution.
-        // If all projects are optional, fall back to using all of them.
         final List<ProjectRef> effectiveRefs;
+
         if (requiredRefs.isEmpty()) {
-            // warning logs go to stderr -- won't pollute stdout
-            log.warn("All projects are marked as optional — using all for version resolution");
-            effectiveRefs = allRefs;
+            log.warn("All projects are marked as optional, using all for version resolution");
+            effectiveRefs = refs;
         } else {
-            if (requiredRefs.size() < allRefs.size()) {
-                final long optionalCount = allRefs.size() - requiredRefs.size();
-                // debug logs go to stderr -- won't pollute stdout
-                log.debug("Excluding {} optional project(s) from Minecraft version resolution", optionalCount);
-            }
             effectiveRefs = requiredRefs;
         }
 
-        final List<List<String>> allGameVersions = Flux.fromIterable(effectiveRefs)
-            .flatMap(projectRef -> {
-                final Loader loader = projectRef.getLoader() != null ? projectRef.getLoader() : defaultLoader;
-                final VersionType allowedVersionType = projectRef.hasVersionType()
-                    ? projectRef.getVersionType()
-                    : defaultVersionType;
-
-                return modrinthApiClient.resolveProjectGameVersions(projectRef, loader, null, allowedVersionType);
-            })
-            .collectList()
-            .block();
-
-        if (allGameVersions != null) {
-            return processGameVersions(allGameVersions);
-        }
-        else {
-            throw new GenericException("Unable to retrieve game versions for projects " + projectRefs);
-        }
+        return effectiveRefs;
     }
 
-    static String processGameVersions(List<List<String>> allGameVersions) {
-        final Map<String, Integer> gameVersionCounts = new HashMap<>();
+    /**
+     * Resolves the Minecraft game versions supported by a Modrinth project.
+     *
+     * @param client Modrinth API client
+     * @param ref Modrinth project 
+     * @return List of supported Minecraft versions 
+     */
+    private Mono<List<String>> resolveVersions(ModrinthApiClient client, ProjectRef ref) {
+        final Loader loader = ref.getLoader() != null ? ref.getLoader() : this.loader;
+        final VersionType allowedVersionType = ref.hasVersionType() ? ref.getVersionType() : defaultVersionType;
 
-        final int projectCount = allGameVersions.size();
+        return client.resolveProjectGameVersions(ref, loader, null, allowedVersionType);
+    }
 
-        // positions will start at the first usable position at end of each list and decrement
-        // and will become negative when finished traversing
-        final int[] positions = new int[projectCount];
-        for (int i = 0; i < projectCount; i++) {
-            positions[i] = allGameVersions.get(i).size() - 1;
+    /**
+     * Calculates the highest compatible Minecraft release across the projects.
+     *
+     * @param officialReleases Minecraft releases
+     * @param refs Required Modrinth projects
+     * @param versions List of supported Versions for each project
+     * @return Compatbile Minecraft release if supported, or an error if no compatible release
+     */
+    private Mono<String> calculateVersion(List<VersionManifestV2.Version> officialReleases, List<ProjectRef> refs, List<List<String>> versions) {
+        final Map<String, Set<Integer>> versionMatrix = buildVersionMatrix(versions);
+        final String version = findHighestCompleteRelease(officialReleases, refs, versionMatrix);
+
+        if (version != null) {
+            return Mono.just(version);
         }
 
-        while (Arrays.stream(positions)
-            // while any position is still usable
-            .anyMatch(p -> p >= 0)
-        ) {
-            for (int i = 0; i < projectCount; i++) {
-                // still usable?
-                if (positions[i] >= 0) {
-                    final int position = positions[i]--;
-                    final String version = allGameVersions.get(i).get(position);
-                    final Integer result = gameVersionCounts.compute(version, (k, count) -> count == null ? 1 : count + 1);
-                    // did this version slot indicate match for all?
-                    if (result == projectCount) {
-                        return version;
-                    }
-                }
+        return Mono.error(new GenericException(describeNoCompatibleRelease(officialReleases, refs, versionMatrix)));
+    }
+
+    /**
+     * Resolves project versions and calculates the highest compatible Minecraft release.
+     *
+     * @param modrinthApiClient Modrinth API client
+     * @param officialReleases Minecraft releases
+     * @return Result containing compatible Minecraft release
+     */
+    private Mono<String> versionFromProjects(
+        ModrinthApiClient modrinthApiClient,
+        List<VersionManifestV2.Version> officialReleases
+    ) {
+        final List<ProjectRef> refs = parseProjects();
+
+        return Flux.fromIterable(refs)
+            .flatMapSequential(projectRef -> {
+                return resolveVersions(modrinthApiClient, projectRef);
+            })
+            .collectList()
+            .flatMap(allProjectVersions -> {
+                return calculateVersion(officialReleases, refs, allProjectVersions);
+            });
+    }
+
+
+    /**
+     * Builds matrix of releases against projects.
+     *
+     * @param versionMatrix List of versions supported per project
+     * @return Map of Minecraft releases against indexs of modrinth projects.
+     */
+    private Map<String, Set<Integer>> buildVersionMatrix(List<List<String>> versionMatrix) {
+        final Map<String, Set<Integer>> supportedByVersion = new HashMap<>();
+
+        for (int projectIndex = 0; projectIndex < versionMatrix.size(); projectIndex++) {
+            for (String gameVersion : new HashSet<>(versionMatrix.get(projectIndex))) {
+                supportedByVersion
+                    .computeIfAbsent(gameVersion, ignored -> new HashSet<>())
+                    .add(projectIndex);
+            }
+        }
+
+        return supportedByVersion;
+    }
+
+
+    /**
+     * Finds the first Minecraft release supported by all required projects.
+     *
+     * @param officialReleases Minecraft releases
+     * @param refs Required Modrinth projects
+     * @param versionMatrix List of versions supported per project
+     * @return the compatible release ID, or {@code null} if no release is supported
+     *         by every project
+     */
+    private String findHighestCompleteRelease(
+        List<VersionManifestV2.Version> officialReleases,
+        List<ProjectRef> refs,
+        Map<String, Set<Integer>> versionMatrix
+    ) {
+        for (VersionManifestV2.Version release : officialReleases) {
+            final Set<Integer> supportedProjects = versionMatrix.getOrDefault(release.getId(), Collections.emptySet());
+            final List<String> missingProjects = missingProjectNames(refs, supportedProjects);
+            if (missingProjects.isEmpty()) {
+                log.debug("Minecraft release {} selected; supported by all {} effective projects",
+                    release.getId(), refs.size());
+                return release.getId();
+            }
+
+            log.debug("Minecraft release {} rejected; missing support from: {}",
+                release.getId(), String.join(", ", missingProjects));
+        }
+
+        return null;
+    }
+
+
     /**
      * Build diagnostic message to describe failure to find compatbile release
      *

--- a/src/main/java/me/itzg/helpers/versions/MinecraftVersionsApi.java
+++ b/src/main/java/me/itzg/helpers/versions/MinecraftVersionsApi.java
@@ -1,6 +1,9 @@
 package me.itzg.helpers.versions;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.InvalidParameterException;
@@ -73,6 +76,25 @@ public class MinecraftVersionsApi {
                     return Mono.just(new MinecraftJarInfo(server.getUrl(), server.getSize(), ChecksumAlgo.SHA1, server.getSha1()));
                 }
                 return Mono.empty();
+            });
+    }
+    /**
+     * Returns a list of all Minecraft releases excluding snapshots, betas / alphas 
+     *
+     * @return List of all Minecraft releases
+     */
+    public Mono<List<Version>> getAllReleases() {
+        return sharedFetch.fetch(
+               manifestUrl 
+            )
+            .toObject(VersionManifestV2.class)
+            .assemble()
+            .flatMap(m -> {
+                return Mono.just(
+                        m.getVersions()
+                        .stream()
+                        .filter(v -> v.getType().equals(VersionManifestV2.VersionType.release))
+                        .collect(Collectors.toList()));
             });
     }
 }

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -133,6 +133,32 @@ class VersionFromModrinthProjectsCommandTest {
     }
 
     @Test
+    void deduplicatesEquivalentProjectReferences(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubProjectVersions("project-one", List.of("1.21.8"));
+
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
+                .execute(
+                    "version-from-modrinth-projects",
+                    "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
+                    "--allowed-version-type", VersionType.release.name(),
+                    "--loader", "paper",
+                    "--projects", "paper:project-one,PAPER:project-one"
+                );
+
+            assertThat(exitCode).isEqualTo(ExitCode.OK);
+        });
+
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.8\n");
+
+        verify(
+            exactly(1),
+            getRequestedFor(urlPathEqualTo("/v2/project/project-one/version"))
+        );
+    }
+
+    @Test
     void returnsFailureWhenProjectsHaveNoCommonRelease(WireMockRuntimeInfo wmInfo) throws Exception {
         stubProjectVersions("project-one", List.of("1.21.6", "1.21.7", "1.21.8"));
         stubProjectVersions("project-two", List.of("1.21.6", "1.21.7", "1.21.8"));

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -103,22 +103,29 @@ class VersionFromModrinthProjectsCommandTest {
     void reportsCoverageAndReturnsFailureWhenNoReleaseMatches(WireMockRuntimeInfo wmInfo) throws Exception {
         stubProjectVersions("project-one", "1.21.10");
         stubProjectVersions("project-two", "1.21.4");
+        final String mcApiUrl = stubMcApi(wmInfo);
 
-        final VersionFromModrinthProjectsCommand command = command(wmInfo);
-        command.baseUrl = wmInfo.getHttpBaseUrl();
-        command.defaultVersionType = VersionType.release;
-        command.projects = List.of("project-one", "project-two");
+        final String err = SystemLambda.tapSystemErr(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
+                .execute(
+                    "--debug",
+                    "version-from-modrinth-projects",
+                    "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", mcApiUrl,
+                    "--allowed-version-type", VersionType.release.name(),
+                    "--projects", "project-one,project-two"
+                );
 
-        assertThat(command.call())
-            .isEqualTo(ExitCode.SOFTWARE);
+            assertThat(exitCode)
+                .isEqualTo(ExitCode.SOFTWARE);
+        });
 
-        assertThat(logAppender.list)
-            .extracting(ILoggingEvent::getFormattedMessage)
+        assertThat(err)
             .contains(
                 "1.21.10: 1/2 projects; missing: project-two",
                 "1.21.4: 1/2 projects; missing: project-one"
             )
-            .noneMatch(message -> message.contains("Closest matches:"));
+            .doesNotContain("Closest matches:");
     }
 
     private void stubGetProjects(String... projects) {

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -26,14 +26,14 @@ import org.slf4j.LoggerFactory;
 class VersionFromModrinthProjectsCommandTest {
 
     private final Logger logger = (Logger) LoggerFactory.getLogger(VersionFromModrinthProjectsCommand.class);
-
     private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    private Level prevLevel;
 
     @BeforeEach
     void startCapturingLogging() {
-        logAppender.start();
-        
+        prevLevel = logger.getLevel();
         logger.setLevel(Level.DEBUG);
+        logAppender.start();
         logger.addAppender(logAppender);
     }
 
@@ -41,6 +41,7 @@ class VersionFromModrinthProjectsCommandTest {
     void stopCapturingLogging() {
         logger.detachAppender(logAppender);
         logAppender.stop();
+        logger.setLevel(prevLevel);
     }
 
     @Test

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -18,12 +18,27 @@ import me.itzg.helpers.modrinth.model.VersionType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
 import org.slf4j.LoggerFactory;
 
 @WireMockTest
 class VersionFromModrinthProjectsCommandTest {
+
+    private final Logger log = (Logger) LoggerFactory.getLogger("me.itzg.helpers");
+    private Level logLevel;
+
+    @BeforeEach
+    void captureLogLeve() {
+        logLevel = log.getLevel();
+    }
+
+    @AfterEach
+    void setLogLevel() {
+        log.setLevel(logLevel);
+    }
 
     @Test
     void testCommand(WireMockRuntimeInfo wmInfo) throws Exception {

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -144,8 +144,8 @@ class VersionFromModrinthProjectsCommandTest {
 
     @Test
     void reportsCoverageAndReturnsFailureWhenNoReleaseMatches(WireMockRuntimeInfo wmInfo) throws Exception {
-        stubProjectVersions("project-one", "1.21.10");
-        stubProjectVersions("project-two", "1.21.4");
+        stubProjectVersions("project-one", List.of("1.21.10"));
+        stubProjectVersions("project-two", List.of("1.21.4"));
         final String mcApiUrl = stubMcApi(wmInfo);
 
         final String err = SystemLambda.tapSystemErr(() -> {
@@ -193,7 +193,7 @@ class VersionFromModrinthProjectsCommandTest {
         return wmInfo.getHttpBaseUrl() + "/mc/game/version_manifest_v2.json";
     }
 
-    private void stubProjectVersions(String project, String gameVersion) {
+    private void stubProjectVersions(String project, List<String> gameVersions) {
         final ObjectMapper mapper = new ObjectMapper();
         final ArrayNode response = mapper.createArrayNode();
 
@@ -202,7 +202,8 @@ class VersionFromModrinthProjectsCommandTest {
             .put("date_published", "2026-01-01T00:00:00Z")
             .put("version_type", "release");
 
-        version.putArray("game_versions").add(gameVersion);
+        final ArrayNode supportedVersions = version.putArray("game_versions");
+        gameVersions.forEach(supportedVersions::add);
 
         stubFor(get(urlEqualTo("/v2/project/" + project + "/version"))
                 .willReturn(aResponse()

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -25,25 +25,6 @@ import org.slf4j.LoggerFactory;
 @WireMockTest
 class VersionFromModrinthProjectsCommandTest {
 
-    private final Logger logger = (Logger) LoggerFactory.getLogger(VersionFromModrinthProjectsCommand.class);
-    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
-    private Level prevLevel;
-
-    @BeforeEach
-    void startCapturingLogging() {
-        prevLevel = logger.getLevel();
-        logger.setLevel(Level.DEBUG);
-        logAppender.start();
-        logger.addAppender(logAppender);
-    }
-
-    @AfterEach
-    void stopCapturingLogging() {
-        logger.detachAppender(logAppender);
-        logAppender.stop();
-        logger.setLevel(prevLevel);
-    }
-
     @Test
     void testCommand(WireMockRuntimeInfo wmInfo) throws Exception {
 

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -132,7 +132,7 @@ class VersionFromModrinthProjectsCommandTest {
         }
     }
 
-    private VersionFromModrinthProjectsCommand command(WireMockRuntimeInfo wmInfo) {
+    private String stubMcApi(WireMockRuntimeInfo wmInfo) {
         stubFor(get(urlPathEqualTo("/mc/game/version_manifest_v2.json"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
@@ -140,10 +140,7 @@ class VersionFromModrinthProjectsCommandTest {
             )
         );
 
-        return new VersionFromModrinthProjectsCommand()
-            .setMinecraftManifestUrl(URI.create(
-                wmInfo.getHttpBaseUrl() + "/mc/game/version_manifest_v2.json"
-            ));
+        return wmInfo.getHttpBaseUrl() + "/mc/game/version_manifest_v2.json";
     }
 
     private void stubProjectVersions(String project, String gameVersion) {

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -16,6 +16,7 @@ import ch.qos.logback.classic.Logger;
 
 import java.util.List;
 
+import me.itzg.helpers.LatchingExecutionExceptionHandler;
 import me.itzg.helpers.McImageHelper;
 import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.modrinth.model.VersionType;
@@ -107,20 +108,38 @@ class VersionFromModrinthProjectsCommandTest {
     }
 
     @Test
-    void rejectsNullProjects() {
-        assertThatThrownBy(() -> new VersionFromModrinthProjectsCommand().call())
+    void rejectsNullProjects() throws Exception {
+
+        final LatchingExecutionExceptionHandler exceptionHandler = new LatchingExecutionExceptionHandler();
+
+        new CommandLine(new McImageHelper())
+            .setExecutionExceptionHandler(exceptionHandler)
+            .execute(
+            "version-from-modrinth-projects"
+        );
+
+        assertThat(exceptionHandler.getExecutionException())
             .isInstanceOf(InvalidParameterException.class)
-            .hasMessage("No projects provided, please provide at least one Modrinth project");
+            .hasMessageContaining("No projects provided, please provide at least one Modrinth project");
+
     }
 
     @Test
-    void rejectsEmptyProjects() {
-        final VersionFromModrinthProjectsCommand command = new VersionFromModrinthProjectsCommand();
-        command.projects = List.of();
+    void rejectsEmptyProjects() throws Exception {
 
-        assertThatThrownBy(command::call)
+        final LatchingExecutionExceptionHandler exceptionHandler = new LatchingExecutionExceptionHandler();
+
+        new CommandLine(new McImageHelper())
+            .setExecutionExceptionHandler(exceptionHandler)
+            .execute(
+            "version-from-modrinth-projects",
+            "--projects="
+        );
+
+        assertThat(exceptionHandler.getExecutionException())
             .isInstanceOf(InvalidParameterException.class)
-            .hasMessage("No projects provided, please provide at least one Modrinth project");
+            .hasMessageContaining("No Modrinth projects parsed successfully, please ensure projects follow \"<loader>:<project ID>|<slug>\" and are delimited by commas");
+
     }
 
     @Test

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -4,6 +4,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -172,15 +175,21 @@ class VersionFromModrinthProjectsCommandTest {
     }
 
     private void stubProjectVersions(String project, String gameVersion) {
-        stubFor(get(urlPathEqualTo("/v2/project/" + project + "/version"))
-            .willReturn(aResponse()
-                .withHeader("Content-Type", "application/json")
-                .withBody(String.format(
-                    "[{\"game_versions\":[\"%s\"],\"id\":\"version-%s\",\"date_published\":\"2026-01-01T00:00:00Z\",\"version_type\":\"release\"}]",
-                    gameVersion,
-                    project
-                ))
-            )
+        final ObjectMapper mapper = new ObjectMapper();
+        final ArrayNode response = mapper.createArrayNode();
+
+        final ObjectNode version = response.addObject()
+            .put("id", "version-" + project)
+            .put("date_published", "2026-01-01T00:00:00Z")
+            .put("version_type", "release");
+
+        version.putArray("game_versions").add(gameVersion);
+
+        stubFor(get(urlEqualTo("/v2/project/" + project + "/version"))
+                .willReturn(aResponse()
+                    .withHeader("Content-Type", "application/json")
+                    .withJsonBody(response)
+                )
         );
     }
 }

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -7,14 +7,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
-import java.net.URI;
+
 import java.util.List;
+
+import me.itzg.helpers.McImageHelper;
 import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.modrinth.model.VersionType;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
-import org.slf4j.LoggerFactory;
 
 @WireMockTest
 class VersionFromModrinthProjectsCommandTest {
@@ -45,10 +46,13 @@ class VersionFromModrinthProjectsCommandTest {
 
         stubGetProjects("viaversion", "viabackwards", "griefprevention", "discordsrv");
 
-        final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(command(wmInfo))
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
                 .execute(
+                    "version-from-modrinth-projects",
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
+                    "--allowed-version-type", VersionType.release.name(),
                     "--projects", "viaversion,viabackwards,griefprevention,discordsrv"
                 );
 
@@ -56,18 +60,19 @@ class VersionFromModrinthProjectsCommandTest {
                 .isEqualTo(ExitCode.OK);
         });
 
-        assertThat(out).isEqualToNormalizingNewlines("1.21.10\n");
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.10\n");
     }
 
     @Test
     void testCommandFabric(WireMockRuntimeInfo wmInfo) throws Exception {
-
         stubGetProjects("fabric-api", "nucledoom");
 
-        final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(command(wmInfo))
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
                 .execute(
+                    "version-from-modrinth-projects",
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
                     "--projects", "fabric-api, nucledoom"
                 );
 
@@ -75,26 +80,27 @@ class VersionFromModrinthProjectsCommandTest {
                 .isEqualTo(ExitCode.OK);
         });
 
-        assertThat(out).isEqualToNormalizingNewlines("1.21.4\n");
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.4\n");
     }
 
     @Test
     void testCommandWithProjectQualifiers(WireMockRuntimeInfo wmInfo) throws Exception {
-
         stubGetProjects("viaversion", "viabackwards", "griefprevention", "discordsrv");
 
-        final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(command(wmInfo))
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitcode = new CommandLine(new McImageHelper())
                 .execute(
+                    "version-from-modrinth-projects",
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
                     "--projects", "paper:viaversion,viabackwards,griefprevention:ue7jAjJ5,discordsrv"
                 );
 
-            assertThat(exitCode)
+            assertThat(exitcode)
                 .isEqualTo(ExitCode.OK);
         });
 
-        assertThat(out).isEqualToNormalizingNewlines("1.21.10\n");
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.10\n");
     }
 
     @Test

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -300,7 +300,7 @@ class VersionFromModrinthProjectsCommandTest {
         final ArrayNode supportedVersions = version.putArray("game_versions");
         gameVersions.forEach(supportedVersions::add);
 
-        stubFor(get(urlEqualTo("/v2/project/" + project + "/version"))
+        stubFor(get(urlPathEqualTo("/v2/project/" + project + "/version"))
                 .willReturn(aResponse()
                     .withHeader("Content-Type", "application/json")
                     .withJsonBody(response)

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -2,7 +2,6 @@ package me.itzg.helpers.modrinth;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -85,6 +84,76 @@ class VersionFromModrinthProjectsCommandTest {
         });
 
         assertThat(stdout).isEqualToNormalizingNewlines("1.21.4\n");
+    }
+
+    @Test
+    void findsHighestReleaseWhenAllProjectsMatch(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubProjectVersions("project-one", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-two", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-three", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-four", List.of("1.21.6", "1.21.7", "1.21.8"));
+
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
+                .execute(
+                    "version-from-modrinth-projects",
+                    "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
+                    "--allowed-version-type", VersionType.release.name(),
+                    "--projects", "project-one,project-two,project-three,project-four"
+                );
+
+            assertThat(exitCode).isEqualTo(ExitCode.OK);
+        });
+
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.8\n");
+    }
+
+    @Test
+    void findsReleaseWhenOneProjectHasShorterVersionList(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubProjectVersions("project-one", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-two", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-three", List.of("1.21.6", "1.21.7"));
+        stubProjectVersions("project-four", List.of("1.21.6", "1.21.7", "1.21.8"));
+
+        final String stdout = SystemLambda.tapSystemOut(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
+                .execute(
+                    "version-from-modrinth-projects",
+                    "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
+                    "--allowed-version-type", VersionType.release.name(),
+                    "--projects", "project-one,project-two,project-three,project-four"
+                );
+
+            assertThat(exitCode).isEqualTo(ExitCode.OK);
+        });
+
+        assertThat(stdout).isEqualToNormalizingNewlines("1.21.7\n");
+    }
+
+    @Test
+    void returnsFailureWhenProjectsHaveNoCommonRelease(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubProjectVersions("project-one", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-two", List.of("1.21.6", "1.21.7", "1.21.8"));
+        stubProjectVersions("project-three", List.of("1.21.4", "1.21.5"));
+        stubProjectVersions("project-four", List.of("1.21.6", "1.21.7", "1.21.8"));
+
+        final String stderr = SystemLambda.tapSystemErr(() -> {
+            final int exitCode = new CommandLine(new McImageHelper())
+                .execute(
+                    "version-from-modrinth-projects",
+                    "--api-base-url", wmInfo.getHttpBaseUrl(),
+                    "--mc-api-base-url", stubMcApi(wmInfo),
+                    "--allowed-version-type", VersionType.release.name(),
+                    "--projects", "project-one,project-two,project-three,project-four"
+                );
+
+            assertThat(exitCode).isEqualTo(ExitCode.SOFTWARE);
+        });
+
+        assertThat(stderr)
+            .contains("Failed to find a compatible Minecraft version across all projects");
     }
 
     @Test

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -1,109 +1,47 @@
 package me.itzg.helpers.modrinth;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.net.URI;
 import java.util.List;
+import me.itzg.helpers.errors.InvalidParameterException;
+import me.itzg.helpers.modrinth.model.VersionType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.FieldSource;
 import picocli.CommandLine;
 import picocli.CommandLine.ExitCode;
+import org.slf4j.LoggerFactory;
 
 @WireMockTest
 class VersionFromModrinthProjectsCommandTest {
 
-    @ParameterizedTest
-    @FieldSource("processGameVersionsArgs")
-    void processGameVersions(List<List<String>> versions, String expected) {
-        final String result = VersionFromModrinthProjectsCommand.processGameVersions(versions);
+    private final Logger logger = (Logger) LoggerFactory.getLogger(VersionFromModrinthProjectsCommand.class);
 
-        if (expected != null) {
-            assertThat(result)
-                .isNotNull()
-                .isEqualTo(expected);
-        }
-        else {
-            assertThat(result)
-                .isNull();
-        }
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+
+    @BeforeEach
+    void startCapturingLogging() {
+        logAppender.start();
+        
+        logger.setLevel(Level.DEBUG);
+        logger.addAppender(logAppender);
     }
 
-    @SuppressWarnings("unused") // will be fixed https://youtrack.jetbrains.com/issue/IDEA-358214/Support-JUnit-5-FieldSource-annotation
-    static List<Arguments> processGameVersionsArgs = asList(
-        argumentSet("matches", asList(
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7", "1.21.8")
-            ), "1.21.8"
-        ),
-        argumentSet("justOneOff", asList(
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7"),
-                asList("1.21.6", "1.21.7", "1.21.8")
-            ), "1.21.7"
-        ),
-        argumentSet("mismatch", asList(
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.6", "1.21.7", "1.21.8"),
-                asList("1.21.4", "1.21.5"),
-                asList("1.21.6", "1.21.7", "1.21.8")
-            ), null
-        ),
-        argumentSet("fabric-api + nucledoom", asList(
-            // part of fabric-api
-                asList("24w46a",
-                    "1.21.4-pre1",
-                    "1.21.4-pre2",
-                    "1.21.4-pre3",
-                    "1.21.4-rc3",
-                    "1.21.4",
-                    "25w02a",
-                    "25w03a",
-                    "25w04a",
-                    "25w05a",
-                    "25w06a",
-                    "25w07a",
-                    "25w08a",
-                    "25w09a",
-                    "25w09b",
-                    "25w10a",
-                    "1.21.5-pre1",
-                    "1.21.5-pre2",
-                    "1.21.5-pre3",
-                    "1.21.5-rc1",
-                    "1.21.5-rc2",
-                    "1.21.5",
-                    "25w14craftmine",
-                    "25w15a",
-                    "25w16a",
-                    "25w17a",
-                    "25w18a",
-                    "25w19a",
-                    "25w20a",
-                    "25w21a",
-                    "1.21.6-pre1",
-                    "1.21.6-pre3",
-                    "1.21.6",
-                    "1.21.7-rc1",
-                    "1.21.7",
-                    "1.21.8",
-                    "25w31a",
-                    "25w32a"),
-            // part of nucledoom
-            singletonList("1.21.4")
-            ), "1.21.4"
-        )
-    );
+    @AfterEach
+    void stopCapturingLogging() {
+        logger.detachAppender(logAppender);
+        logAppender.stop();
+    }
 
     @Test
     void testCommand(WireMockRuntimeInfo wmInfo) throws Exception {
@@ -111,7 +49,7 @@ class VersionFromModrinthProjectsCommandTest {
         stubGetProjects("viaversion", "viabackwards", "griefprevention", "discordsrv");
 
         final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(new VersionFromModrinthProjectsCommand())
+            final int exitCode = new CommandLine(command(wmInfo))
                 .execute(
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
                     "--projects", "viaversion,viabackwards,griefprevention,discordsrv"
@@ -130,7 +68,7 @@ class VersionFromModrinthProjectsCommandTest {
         stubGetProjects("fabric-api", "nucledoom");
 
         final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(new VersionFromModrinthProjectsCommand())
+            final int exitCode = new CommandLine(command(wmInfo))
                 .execute(
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
                     "--projects", "fabric-api, nucledoom"
@@ -149,7 +87,7 @@ class VersionFromModrinthProjectsCommandTest {
         stubGetProjects("viaversion", "viabackwards", "griefprevention", "discordsrv");
 
         final String out = SystemLambda.tapSystemOut(() -> {
-            final int exitCode = new CommandLine(new VersionFromModrinthProjectsCommand())
+            final int exitCode = new CommandLine(command(wmInfo))
                 .execute(
                     "--api-base-url", wmInfo.getHttpBaseUrl(),
                     "--projects", "paper:viaversion,viabackwards,griefprevention:ue7jAjJ5,discordsrv"
@@ -162,6 +100,45 @@ class VersionFromModrinthProjectsCommandTest {
         assertThat(out).isEqualToNormalizingNewlines("1.21.10\n");
     }
 
+    @Test
+    void rejectsNullProjects() {
+        assertThatThrownBy(() -> new VersionFromModrinthProjectsCommand().call())
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessage("No projects provided, please provide at least one Modrinth project");
+    }
+
+    @Test
+    void rejectsEmptyProjects() {
+        final VersionFromModrinthProjectsCommand command = new VersionFromModrinthProjectsCommand();
+        command.projects = List.of();
+
+        assertThatThrownBy(command::call)
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessage("No projects provided, please provide at least one Modrinth project");
+    }
+
+    @Test
+    void reportsCoverageAndReturnsFailureWhenNoReleaseMatches(WireMockRuntimeInfo wmInfo) throws Exception {
+        stubProjectVersions("project-one", "1.21.10");
+        stubProjectVersions("project-two", "1.21.4");
+
+        final VersionFromModrinthProjectsCommand command = command(wmInfo);
+        command.baseUrl = wmInfo.getHttpBaseUrl();
+        command.defaultVersionType = VersionType.release;
+        command.projects = List.of("project-one", "project-two");
+
+        assertThat(command.call())
+            .isEqualTo(ExitCode.SOFTWARE);
+
+        assertThat(logAppender.list)
+            .extracting(ILoggingEvent::getFormattedMessage)
+            .contains(
+                "1.21.10: 1/2 projects; missing: project-two",
+                "1.21.4: 1/2 projects; missing: project-one"
+            )
+            .noneMatch(message -> message.contains("Closest matches:"));
+    }
+
     private void stubGetProjects(String... projects) {
         for (final String project : projects) {
             stubFor(get(urlPathEqualTo("/v2/project/" + project + "/version"))
@@ -171,5 +148,32 @@ class VersionFromModrinthProjectsCommandTest {
                 )
             );
         }
+    }
+
+    private VersionFromModrinthProjectsCommand command(WireMockRuntimeInfo wmInfo) {
+        stubFor(get(urlPathEqualTo("/mc/game/version_manifest_v2.json"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBodyFile("minecraft-version-manifest.json")
+            )
+        );
+
+        return new VersionFromModrinthProjectsCommand()
+            .setMinecraftManifestUrl(URI.create(
+                wmInfo.getHttpBaseUrl() + "/mc/game/version_manifest_v2.json"
+            ));
+    }
+
+    private void stubProjectVersions(String project, String gameVersion) {
+        stubFor(get(urlPathEqualTo("/v2/project/" + project + "/version"))
+            .willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBody(String.format(
+                    "[{\"game_versions\":[\"%s\"],\"id\":\"version-%s\",\"date_published\":\"2026-01-01T00:00:00Z\",\"version_type\":\"release\"}]",
+                    gameVersion,
+                    project
+                ))
+            )
+        );
     }
 }

--- a/src/test/resources/__files/minecraft-version-manifest.json
+++ b/src/test/resources/__files/minecraft-version-manifest.json
@@ -10,6 +10,26 @@
       "url": "https://example.invalid/1.21.10.json"
     },
     {
+      "id": "1.21.8",
+      "type": "release",
+      "url": "https://example.invalid/1.21.8.json"
+    },
+    {
+      "id": "1.21.7",
+      "type": "release",
+      "url": "https://example.invalid/1.21.7.json"
+    },
+    {
+      "id": "1.21.6",
+      "type": "release",
+      "url": "https://example.invalid/1.21.6.json"
+    },
+    {
+      "id": "1.21.5",
+      "type": "release",
+      "url": "https://example.invalid/1.21.5.json"
+    },
+    {
       "id": "1.21.4",
       "type": "release",
       "url": "https://example.invalid/1.21.4.json"

--- a/src/test/resources/__files/minecraft-version-manifest.json
+++ b/src/test/resources/__files/minecraft-version-manifest.json
@@ -1,0 +1,23 @@
+{
+  "latest": {
+    "release": "1.21.10",
+    "snapshot": "25w32a"
+  },
+  "versions": [
+    {
+      "id": "1.21.10",
+      "type": "release",
+      "url": "https://example.invalid/1.21.10.json"
+    },
+    {
+      "id": "1.21.4",
+      "type": "release",
+      "url": "https://example.invalid/1.21.4.json"
+    },
+    {
+      "id": "25w32a",
+      "type": "snapshot",
+      "url": "https://example.invalid/25w32a.json"
+    }
+  ]
+}


### PR DESCRIPTION
Reworked the internal logic of `VersionFromModrinthProjectsCommand` to support #630 and #676.

## Version Blame #676
When a specific Modrinth project is blocking a release, a debug log is printed specifying the project that is blocking that version, e.g.

```bash
./gradlew run --args="--debug version-from-modrinth-projects --loader=paper --projects=paper:viaversion,paper:viabackwards,paper:griefprevention,paper:discordsrv,paper:pl3xmap:beta"
```

```
[mc-image-helper] 23:19:15.426 DEBUG : 26.2: 4/5 projects; missing: griefprevention
[mc-image-helper] 23:19:15.426 DEBUG : 26.1.2: 5/5 projects
```

Furthermore, if no compatible version is found, the same DEBUG logs are printed per version, as well as a final error;

```
[mc-image-helper] 23:20:27.039 ERROR : Failed to find a compatible Minecraft version across all projects
```

## Empty Projects and No Projects #630
When passing `--projects=` with no data, an error is thrown
```
./gradlew run --args="--debug version-from-modrinth-projects --projects="
``` 

```
[mc-image-helper] 22:37:41.380 ERROR : Invalid parameter provided for 'version-from-modrinth-projects' command: No Modrinth projects parsed successfully, please ensure projects follow "<loader>:<project ID>|<slug>" and are delimited by commas
```
If no projects provided, another error is thrown.

```
./gradlew run --args="--debug version-from-modrinth-projects"
```

```
[mc-image-helper] 22:38:46.338 ERROR : Invalid parameter provided for 'version-from-modrinth-projects' command: No projects provided, please provide at least one Modrinth project
```