### PR TITLE
cf: say when a mod page URL is given to install-curseforge #685

### DIFF
--- a/src/main/java/me/itzg/helpers/curseforge/ModpacksPageUrlParser.java
+++ b/src/main/java/me/itzg/helpers/curseforge/ModpacksPageUrlParser.java
@@ -11,7 +11,7 @@ class ModpacksPageUrlParser {
     private static final Pattern PAGE_URL_PATTERN = Pattern.compile(
         "https://(www|beta)\\.curseforge\\.com/minecraft/modpacks/(?<slug>[^/]+?)(/((files|download)(/(?<fileId>\\d+)?)?)?)?");
 
-    private static final Pattern MINECRAFT_PAGE_URL_PATTERN = Pattern.compile(
+    private static final Pattern PAGE_CATEGORY_URL_PATTERN = Pattern.compile(
         "https://(www|beta)\\.curseforge\\.com/minecraft/(?<category>[^/]+)/.*");
 
     @Data @Builder
@@ -43,9 +43,9 @@ class ModpacksPageUrlParser {
             }
         }
 
-        final Matcher other = MINECRAFT_PAGE_URL_PATTERN.matcher(pageUrl);
-        if (other.matches()) {
-            final String category = other.group("category");
+        final Matcher categoryMatcher = PAGE_CATEGORY_URL_PATTERN.matcher(pageUrl);
+        if (categoryMatcher.matches()) {
+            final String category = categoryMatcher.group("category");
             if (!CurseForgeApiClient.CATEGORY_MODPACKS.equals(category)) {
                 String message = "install-curseforge expects a modpack page URL such as "
                     + "https://www.curseforge.com/minecraft/modpacks/<slug>, not a "

--- a/src/main/java/me/itzg/helpers/curseforge/ModpacksPageUrlParser.java
+++ b/src/main/java/me/itzg/helpers/curseforge/ModpacksPageUrlParser.java
@@ -11,6 +11,9 @@ class ModpacksPageUrlParser {
     private static final Pattern PAGE_URL_PATTERN = Pattern.compile(
         "https://(www|beta)\\.curseforge\\.com/minecraft/modpacks/(?<slug>[^/]+?)(/((files|download)(/(?<fileId>\\d+)?)?)?)?");
 
+    private static final Pattern MINECRAFT_PAGE_URL_PATTERN = Pattern.compile(
+        "https://(www|beta)\\.curseforge\\.com/minecraft/(?<category>[^/]+)/.*");
+
     @Data @Builder
     public static class Parsed {
         String slug;
@@ -39,10 +42,22 @@ class ModpacksPageUrlParser {
                     .build();
             }
         }
-        else {
-            throw new InvalidParameterException("Unexpected CF page URL structure: " + pageUrl);
+
+        final Matcher other = MINECRAFT_PAGE_URL_PATTERN.matcher(pageUrl);
+        if (other.matches()) {
+            final String category = other.group("category");
+            if (!CurseForgeApiClient.CATEGORY_MODPACKS.equals(category)) {
+                String message = "install-curseforge expects a modpack page URL such as "
+                    + "https://www.curseforge.com/minecraft/modpacks/<slug>, not a "
+                    + category + " page: " + pageUrl;
+                if (CurseForgeApiClient.CATEGORY_MC_MODS.equals(category)
+                    || CurseForgeApiClient.CATEGORY_BUKKIT_PLUGINS.equals(category)) {
+                    message += ". Use curseforge-files for individual mods or plugins.";
+                }
+                throw new InvalidParameterException(message);
+            }
         }
 
-
+        throw new InvalidParameterException("Unexpected CF page URL structure: " + pageUrl);
     }
 }

--- a/src/test/java/me/itzg/helpers/curseforge/ModpacksPageUrlParserTest.java
+++ b/src/test/java/me/itzg/helpers/curseforge/ModpacksPageUrlParserTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import me.itzg.helpers.curseforge.ModpacksPageUrlParser.Parsed;
 import me.itzg.helpers.errors.InvalidParameterException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -46,5 +47,14 @@ class ModpacksPageUrlParserTest {
     void invalid(String url) {
         assertThatThrownBy(() -> ModpacksPageUrlParser.parse(url))
             .isInstanceOf(InvalidParameterException.class);
+    }
+
+    @Test
+    void modPageInsteadOfModpack() {
+        assertThatThrownBy(() -> ModpacksPageUrlParser.parse(
+            "https://www.curseforge.com/minecraft/mc-mods/timeless-and-classics-zero/files/7278003"))
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining("not a mc-mods page")
+            .hasMessageContaining("curseforge-files");
     }
 }


### PR DESCRIPTION
A CurseForge mod file URL was failing as "Unexpected CF page URL structure", which looks like an API key problem.

install-curseforge now says the URL is an mc-mods (or other non-modpack) page and points at curseforge-files for individual mods.

Fixes #685
