### PR TITLE
modrinth: version-from-modrinth-projects improved logging and error handling

### DIFF
--- a/src/main/java/me/itzg/helpers/modrinth/ProjectRef.java
+++ b/src/main/java/me/itzg/helpers/modrinth/ProjectRef.java
@@ -12,6 +12,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import me.itzg.helpers.errors.InvalidParameterException;
@@ -20,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class ProjectRef {
     private static final Pattern VERSIONS = Pattern.compile("[a-zA-Z0-9]{8}");
     private static final Pattern MODPACK_PAGE_URL = Pattern.compile(

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -5,10 +5,13 @@ import static me.itzg.helpers.McImageHelper.SPLIT_SYNOPSIS_COMMA_NL;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
 import me.itzg.helpers.http.SharedFetchArgs;
@@ -119,7 +122,9 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
     }
 
     static String processGameVersions(List<List<String>> allGameVersions) {
-        final Map<String, Integer> gameVersionCounts = new HashMap<>();
+
+        final Map<String, int[]> gameVersionPositions = new HashMap<>();
+        final Set<String> loggedBlockedVersions = new HashSet<>();
 
         final int projectCount = allGameVersions.size();
 
@@ -139,10 +144,33 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                 if (positions[i] >= 0) {
                     final int position = positions[i]--;
                     final String version = allGameVersions.get(i).get(position);
-                    final Integer result = gameVersionCounts.compute(version, (k, count) -> count == null ? 1 : count + 1);
+
+                    final int[] projectPositions = gameVersionPositions.computeIfAbsent(version, ignored -> {
+                        final int[] result = new int[projectCount];
+                        Arrays.fill(result, -1);
+                        return result;
+                    });
+
+                    // Prevent duplicate entries from the same project counting twice.
+                    if (projectPositions[i] < 0) {
+                        projectPositions[i] = position;
+                    }
+
                     // did this version slot indicate match for all?
-                    if (result == projectCount) {
+                    if (Arrays.stream(projectPositions).allMatch(projectPosition -> projectPosition >= 0)) {
                         return version;
+                    }
+
+                    if (log.isDebugEnabled() && !loggedBlockedVersions.contains(version)) {
+                        final List<Integer> blockingProjects = IntStream.range(0, projectCount)
+                            .filter(projectIndex -> !allGameVersions.get(projectIndex).contains(version))
+                            .boxed()
+                            .collect(Collectors.toList());
+
+                        if (!blockingProjects.isEmpty()) {
+                            loggedBlockedVersions.add(version);
+                            log.debug("Minecraft version {} is blocked by project indexes {}", version, blockingProjects);
+                        }
                     }
                 }
             }

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -102,7 +102,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
         }
 
         final List<List<String>> allGameVersions = Flux.fromIterable(effectiveRefs)
-            .flatMap(projectRef -> {
+            .flatMapSequential(projectRef -> {
                 final Loader loader = projectRef.getLoader() != null ? projectRef.getLoader() : defaultLoader;
                 final VersionType allowedVersionType = projectRef.hasVersionType()
                     ? projectRef.getVersionType()

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -8,12 +8,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import me.itzg.helpers.errors.GenericException;
+import me.itzg.helpers.errors.InvalidParameterException;
 import me.itzg.helpers.http.SharedFetchArgs;
 import me.itzg.helpers.modrinth.model.VersionType;
 import picocli.CommandLine.ArgGroup;
@@ -75,11 +77,19 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
         }
     }
 
-    static String versionFromProjects(ModrinthApiClient modrinthApiClient, List<String> projectRefs, Loader defaultLoader, VersionType defaultVersionType) {
+    static String versionFromProjects(ModrinthApiClient modrinthApiClient, List<String> projectRefs, Loader defaultLoader, VersionType defaultVersionType) throws InvalidParameterException {
         // Parse all refs and separate optional from required
         final List<ProjectRef> allRefs = projectRefs.stream()
+            .filter(Objects::nonNull)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
             .map(ProjectRef::parse)
+            .distinct()
             .collect(Collectors.toList());
+
+        if (allRefs.isEmpty()) {
+            throw new InvalidParameterException("No Modrinth projects parsed successfully, please ensure projects follow \"<loader>:<project ID>|<slug>\" and are delimited by commas");
+        }
 
         final List<ProjectRef> requiredRefs = allRefs.stream()
             .filter(ref -> !ref.isOptional())

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -63,6 +63,11 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+
+        if (projects == null || projects.isEmpty()) {
+            throw new InvalidParameterException("No Modrinth projects provided, please provide at least one Modrinth project");
+        }
+
         try (ModrinthApiClient modrinthApiClient = new ModrinthApiClient(baseUrl, "modrinth", sharedFetchArgs.options())) {
             final String version = versionFromProjects(modrinthApiClient, projects, loader, defaultVersionType);
 

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -124,7 +124,7 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                     : defaultVersionType;
 
                 return modrinthApiClient.resolveProjectGameVersions(projectRef, loader, null, allowedVersionType)
-                    .onErrorMap(error -> new GenericException("Failed to resolve project version for " + projectRef.getIdOrSlug()));
+                    .onErrorMap(error -> new GenericException("Failed to resolve project version for " + projectRef.getIdOrSlug(), error));
             })
             .collectList()
             .block();

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -114,14 +114,14 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
             .block();
 
         if (allGameVersions != null) {
-            return processGameVersions(allGameVersions);
+            return processGameVersions(allGameVersions, effectiveRefs);
         }
         else {
             throw new GenericException("Unable to retrieve game versions for projects " + projectRefs);
         }
     }
 
-    static String processGameVersions(List<List<String>> allGameVersions) {
+    static String processGameVersions(List<List<String>> allGameVersions, List<ProjectRef> projects) {
 
         final Map<String, int[]> gameVersionPositions = new HashMap<>();
         final Set<String> loggedBlockedVersions = new HashSet<>();
@@ -169,7 +169,11 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
 
                         if (!blockingProjects.isEmpty()) {
                             loggedBlockedVersions.add(version);
-                            log.debug("Minecraft version {} is blocked by project indexes {}", version, blockingProjects);
+                            log.debug("Minecraft version {} is blocked by projects {}", version, 
+                                    blockingProjects.stream()
+                                    .map(projects::get)
+                                    .map(p -> p.getIdOrSlug())
+                                    .collect(Collectors.toList()));
                         }
                     }
                 }

--- a/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
+++ b/src/main/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommand.java
@@ -123,7 +123,8 @@ public class VersionFromModrinthProjectsCommand implements Callable<Integer> {
                     ? projectRef.getVersionType()
                     : defaultVersionType;
 
-                return modrinthApiClient.resolveProjectGameVersions(projectRef, loader, null, allowedVersionType);
+                return modrinthApiClient.resolveProjectGameVersions(projectRef, loader, null, allowedVersionType)
+                    .onErrorMap(error -> new GenericException("Failed to resolve project version for " + projectRef.getIdOrSlug()));
             })
             .collectList()
             .block();

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -177,6 +177,19 @@ class VersionFromModrinthProjectsCommandTest {
     }
 
     @Test
+    void testCommandHandlesNullProjects() throws Exception {
+        final LatchingExecutionExceptionHandler exceptionHandler = new LatchingExecutionExceptionHandler();
+
+        new CommandLine(new McImageHelper())
+            .setExecutionExceptionHandler(exceptionHandler)
+            .execute("version-from-modrinth-projects");
+
+        assertThat(exceptionHandler.getExecutionException())
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining("No Modrinth projects provided, please provide at least one Modrinth project");
+    }
+
+    @Test
     void testCommandWithProjectQualifiers(WireMockRuntimeInfo wmInfo) throws Exception {
 
         stubGetProjects("viaversion", "viabackwards", "griefprevention", "discordsrv");

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -10,6 +10,10 @@ import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 
+import me.itzg.helpers.LatchingExecutionExceptionHandler;
+import me.itzg.helpers.McImageHelper;
+import me.itzg.helpers.errors.InvalidParameterException;
+
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -152,6 +156,24 @@ class VersionFromModrinthProjectsCommandTest {
         });
 
         assertThat(out).isEqualToNormalizingNewlines("1.21.4\n");
+    }
+
+    @Test
+    void testCommandHanlesEmptyProjects() throws Exception {
+
+        final LatchingExecutionExceptionHandler exceptionHandler = new LatchingExecutionExceptionHandler();
+
+        new CommandLine(new McImageHelper())
+            .setExecutionExceptionHandler(exceptionHandler)
+            .execute(
+                "--debug",
+                 "version-from-modrinth-projects",
+                "--projects="
+                );
+
+        assertThat(exceptionHandler.getExecutionException())
+            .isInstanceOf(InvalidParameterException.class)
+            .hasMessageContaining("No Modrinth projects parsed successfully, please ensure projects follow \"<loader>:<project ID>|<slug>\" and are delimited by commas");
     }
 
     @Test

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -166,7 +166,6 @@ class VersionFromModrinthProjectsCommandTest {
         new CommandLine(new McImageHelper())
             .setExecutionExceptionHandler(exceptionHandler)
             .execute(
-                "--debug",
                  "version-from-modrinth-projects",
                 "--projects="
                 );

--- a/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
+++ b/src/test/java/me/itzg/helpers/modrinth/VersionFromModrinthProjectsCommandTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,7 +25,16 @@ class VersionFromModrinthProjectsCommandTest {
     @ParameterizedTest
     @FieldSource("processGameVersionsArgs")
     void processGameVersions(List<List<String>> versions, String expected) {
-        final String result = VersionFromModrinthProjectsCommand.processGameVersions(versions);
+
+        List<ProjectRef> projects = new ArrayList<>();
+
+        for (int i = 0; i < versions.size(); ++i) {
+            projects.add(new ProjectRef("test-project-" + Integer.toString(i), null));
+        }
+
+        System.out.println(projects.toString());
+
+        final String result = VersionFromModrinthProjectsCommand.processGameVersions(versions, projects);
 
         if (expected != null) {
             assertThat(result)


### PR DESCRIPTION
Revision of #854, added logging and error handling supporting #630, #676

## Version Blame
When running `version-from-modrinth-projects` fails, and `--debug` is passed, logs are printed, noting which modrinth projects are blocking each Minecraft version.

```bash
./gradlew run --args="--debug version-from-modrinth-projects --loader=paper --projects=paper:viaversion,paper:viabackwards,paper:griefprevention,paper:discordsrv,paper:pl3xmap"
```

```text
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 26.2 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 26.1.2 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 26.1.1 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 26.1 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.11 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.10 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.9 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.8 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.7 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.6 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.5 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.4 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.3 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.2 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21.1 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.21 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.20.6 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.345 DEBUG : Minecraft version 1.20.5 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.20.4 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.20.3 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.20.2 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.20.1 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.20 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.19.4 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.19.3 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.19.2 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.19.1 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.19 is blocked by projects [pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.18.2 is blocked by projects [griefprevention, pl3xmap]
[mc-image-helper] 00:13:20.346 DEBUG : Minecraft version 1.18.1 is blocked by projects [griefprevention, pl3xmap]
```

## Empty and Null project Exceptions
When an empty projects list is passed, or no projects are parsed, `InvalidParameterException` is thrown

```bash
./gradlew run --args="version-from-modrinth-projects --projects= "
```
```text
[mc-image-helper] 00:16:38.571 ERROR : Invalid parameter provided for 'version-from-modrinth-projects' command: No Modrinth projects parsed successfully, please ensure projects follow "<loader>:<project ID>|<slug>" and are delimited by commas
```
```bash
./gradlew run --args="version-from-modrinth-projects"
```
```text
[mc-image-helper] 00:17:00.844 ERROR : Invalid parameter provided for 'version-from-modrinth-projects' command: No Modrinth projects provided, please provide at least one Modrinth project
```

Added tests asserting errors thrown for both cases.

## ProjectRef parse tightening
Tightens initial ref passthrough; filtering whitespace and duplicate entries.